### PR TITLE
refactor Makefile to avoid rebuilds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Local node installation
 node_modules/
+.docker-build

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,21 @@
 PWD ?= $(shell pwd)
 
+
+clean:
+	rm -fr .docker-build
+
 build:
 	docker build -f docker/Dockerfile -t mdnwebdocs/stump:latest .
+	touch .docker-build
 
-lint: build
+build-conditional:
+	ls .docker-build || make build
+
+lint: build-conditional
 	docker run --volume ${PWD}:/app --workdir /app mdnwebdocs/stump:latest ./scripts/lint.sh
 
-validate: build
+validate: build-conditional
 	docker run --volume ${PWD}:/app --workdir /app mdnwebdocs/stump:latest ./scripts/validate.py
 
 # Those tasks don't have file targets
-.PHONY: build lint validate
+.PHONY: clean build lint validate


### PR DESCRIPTION
Now you can run `make lint` (or `make validate`) repeatedly without having to trigger the docker build every time. 