### PR TITLE
Add mdn-url to JSON

### DIFF
--- a/scripts/build-json/build-page-json.js
+++ b/scripts/build-json/build-page-json.js
@@ -48,6 +48,7 @@ function buildPageJSON(elementPath) {
     // make the package
     const element = {};
     element.title = meta.title;
+    element.mdn_url = meta['mdn-url'];
     element.interactive_example_url = meta['interactive-example'];
     element.browser_compatibility = bcd.package(meta['browser-compatibility']);
     if (meta.attributes['element-specific']) {


### PR DESCRIPTION
This exposes meta.yaml's "mdn-url" in the JSON.

(@peterbe : I've been horribly inconsistent with using "the-thing" or "the\_thing". I think we should probably use "the\_thing" throughout. Let me know what you think though and I'll make the change in a followup.)
