### PR TITLE
Add partial HTML rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 .docker-build
 packaged
+rendered

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
         "prettify": "prettier --write scripts/**/*.js",
         "lint-md": "remark content",
         "build-json": "node scripts/build-json/build-json.js",
+        "render-html": "node scripts/render-html/render-html.js",
         "spell-md": "mdspell -a -n --en-us 'content/**/*.md'"
     },
     "dependencies": {
+        "escape-html": "1.0.3",
         "gray-matter": "4.0.2",
         "js-yaml": "3.13.1",
         "jsdom": "^12.2.0",

--- a/scripts/build-json/compose-attributes.js
+++ b/scripts/build-json/compose-attributes.js
@@ -9,10 +9,10 @@ const bcd = require('mdn-browser-compat-data');
 
 const { JSDOM } = jsdom;
 
-function extractFromSiblings(node, terminatorTag, contentType) {
+function extractFromSiblings(node, terminatorTags, contentType) {
     let content = '';
     let sib = node.nextSibling;
-    while (sib && sib.nodeName != terminatorTag) {
+    while (sib && !terminatorTags.includes(sib.nodeName)) {
         if (sib.outerHTML) {
             if (contentType === 'html') {
                 content += sib.outerHTML;
@@ -31,7 +31,7 @@ function packageValues(heading, dom) {
     for (let valueHeading of valueHeadings) {
         let value = {
             value: valueHeading.textContent,
-            description: extractFromSiblings(valueHeading, 'H3', 'html')
+            description: extractFromSiblings(valueHeading, ['H2', 'H3'], 'html')
         }
         values.push(value);
     }
@@ -49,12 +49,12 @@ function packageAttribute(attributePath) {
     attribute.name = name.textContent;
 
     // extract the description property
-    attribute.description = extractFromSiblings(name, 'H2', 'html');
+    attribute.description = extractFromSiblings(name, ['H2'], 'html');
 
     // extract the type property
     const h2Headings = dom.querySelectorAll('h2');
     const typeHeading = (h2Headings.length === 2)? h2Headings[1]: h2Headings[0];
-    attribute.type = extractFromSiblings(typeHeading, 'H2', 'text');
+    attribute.type = extractFromSiblings(typeHeading, ['H2'], 'text');
 
     // extract the values property
     if (h2Headings.length === 2) {

--- a/scripts/build-json/slice-prose.js
+++ b/scripts/build-json/slice-prose.js
@@ -34,19 +34,6 @@ function extractFromSiblings(node, terminatorTag, contentType) {
     return content;
 }
 
-function packageValues(heading, dom) {
-    const values = [];
-    const valueHeadings = dom.querySelectorAll('h3');
-    for (let valueHeading of valueHeadings) {
-        let value = {
-            value: valueHeading.textContent,
-            description: extractFromSiblings(valueHeading, 'H3', 'html')
-        }
-        values.push(value);
-    }
-    return values;
-}
-
 function getSection(node, sections) {
     const sectionName = node.textContent.trim();
     const sectionContent = extractFromSiblings(node, '#comment', 'html');

--- a/scripts/render-html/render-attributes.js
+++ b/scripts/render-html/render-attributes.js
@@ -1,6 +1,7 @@
 
 function renderAttribute(attribute) {
     let rendered = '<dt>';
+
     rendered += `<code>${attribute.name}</code>`
     rendered += '</dt>';
 
@@ -14,11 +15,13 @@ function renderAttribute(attribute) {
 
 function renderAttributes(attributes) {
     let rendered = '<h2>Attributes</h2>';
+
     rendered += '<dl>';
     for (let attribute of attributes) {
         rendered += renderAttribute(attribute);
     }
     rendered += '</dl>';
+
     return rendered;
 }
 

--- a/scripts/render-html/render-attributes.js
+++ b/scripts/render-html/render-attributes.js
@@ -1,0 +1,27 @@
+
+function renderAttribute(attribute) {
+    let rendered = '<dt>';
+    rendered += `<code>${attribute.name}</code>`
+    rendered += '</dt>';
+
+    rendered += '<dd>';
+    rendered += `<strong>${attribute.type}</strong>`;
+    rendered += attribute.description;
+    rendered += '</dd>';
+
+    return rendered;
+}
+
+function renderAttributes(attributes) {
+    let rendered = '<h2>Attributes</h2>';
+    rendered += '<dl>';
+    for (let attribute of attributes) {
+        rendered += renderAttribute(attribute);
+    }
+    rendered += '</dl>';
+    return rendered;
+}
+
+module.exports = {
+    renderAttributes
+}

--- a/scripts/render-html/render-attributes.js
+++ b/scripts/render-html/render-attributes.js
@@ -27,9 +27,12 @@ function renderAttribute(attribute) {
     return rendered;
 }
 
-function renderAttributes(attributes) {
+function renderAttributes(attributesText, attributes) {
     let rendered = '<h2>Attributes</h2>';
 
+    if (attributesText) {
+        rendered += attributesText;
+    }
     rendered += '<dl>';
     for (let attribute of attributes) {
         rendered += renderAttribute(attribute);

--- a/scripts/render-html/render-attributes.js
+++ b/scripts/render-html/render-attributes.js
@@ -1,3 +1,14 @@
+function renderValues(values) {
+    let rendered = '<ul>';
+
+    for (let value of values) {
+        rendered += `<li><code>${value.value}</code>: ${value.description}</li>`;
+    }
+    rendered += '</ul>';
+
+    return rendered;
+}
+
 
 function renderAttribute(attribute) {
     let rendered = '<dt>';
@@ -8,6 +19,9 @@ function renderAttribute(attribute) {
     rendered += '<dd>';
     rendered += `<strong>${attribute.type}</strong>`;
     rendered += attribute.description;
+    if (attribute.values) {
+        rendered += renderValues(attribute.values);
+    }
     rendered += '</dd>';
 
     return rendered;

--- a/scripts/render-html/render-examples.js
+++ b/scripts/render-html/render-examples.js
@@ -1,0 +1,76 @@
+const escape = require('escape-html');
+
+function renderSources(example) {
+    let rendered = '';
+
+    if (example.sources.html) {
+        rendered += '<h4>HTML</h4>';
+        rendered += `<pre><code>${escape(example.sources.html)}</code></pre>`;
+    }
+  
+    if (example.sources.css) {
+        rendered += '<h4>CSS</h4>';
+        rendered += `<pre><code>${escape(example.sources.css)}</code></pre>`;
+    }
+  
+    if (example.sources.js) {
+        rendered += '<h4>JavaScript</h4>';
+        rendered += `<pre><code>${escape(example.sources.js)}</code></pre>`;
+    }
+
+    return rendered;
+}
+
+function renderLiveSample(example) {
+
+    const srcdoc = 
+`<html>
+  <head>
+      <meta charset="utf-8">
+      <style type="text/css">${example.sources.css}</style>
+      <title>${example.description.title}</title>
+  </head>
+  <body>${example.sources.html}
+      <script>${example.sources.js}</script>
+  </body>
+</html>`;
+
+    const iframe = 
+`<iframe class="live-sample-frame sample-code-frame" id="frame_Live_example"
+    srcdoc="${escape(srcdoc)}"
+    width="${example.description.width}px"
+    height="${example.description.height}px"
+    frameborder="0">
+</iframe>`;
+
+    return `<h4>Result</h4>${iframe}`;
+}
+
+function renderExample(example) {
+    let rendered = '';
+
+    if (example.description.title) {
+        rendered += `<h3>${escape(example.description.title)}</h3>`;
+        rendered += example.description.content;
+    }
+
+    rendered += renderSources(example);
+
+    if (example.description.width) {
+        rendered += renderLiveSample(example);
+    }
+
+    return rendered;
+}
+
+function renderExamples(examples) {
+    let rendered = '<h2>Examples</h2>';
+    for (let example of examples) {
+        rendered += renderExample(example);
+    }
+    return rendered;
+}
+
+module.exports = {
+    renderExamples
+}

--- a/scripts/render-html/render-html.js
+++ b/scripts/render-html/render-html.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+
+const escape = require('escape-html');
+const { renderIE } = require('./render-ie');
+const { renderAttributes } = require('./render-attributes');
+const { renderExamples } = require('./render-examples');
+
+const writeToFile = (elementName, html) => {
+    const destDir = path.join(process.cwd(),'rendered/html/elements');
+    if (!fs.existsSync(destDir)) {
+      fs.mkdirSync(destDir, { recursive: true });
+  }
+    fs.writeFileSync(path.join(destDir, `${elementName}.html`), html);
+};
+
+function renderHTML(elementName) {
+    elementPath = path.join(process.cwd(), './packaged/html/elements', `${elementName}.json`);
+
+    if (!fs.existsSync(elementPath)) {
+        console.error(`Could not find an item at "${elementPath}"`);
+        return 1;
+    }
+
+    const elementJSON = JSON.parse(fs.readFileSync(elementPath, 'utf8')).html.elements[elementName];
+
+    let rendered =
+`<!DOCTYPE html>
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>${elementJSON.title}</title>
+  </head>
+<body>`;
+    rendered += `<h1>${escape(elementJSON.title)}</h1>\n`;
+    rendered += `${elementJSON.prose['short-description']}\n`;
+    rendered += renderIE(elementJSON.interactive_example_url);
+    rendered += `${elementJSON.prose.overview}\n`;
+    rendered += renderAttributes(elementJSON.attributes);
+    rendered += renderExamples(elementJSON.examples);
+    rendered += '</body></html>';
+
+    writeToFile(elementName, rendered);
+}
+
+renderHTML(process.argv.slice(2));

--- a/scripts/render-html/render-html.js
+++ b/scripts/render-html/render-html.js
@@ -37,8 +37,14 @@ function renderHTML(elementName) {
     rendered += `${elementJSON.prose['short-description']}\n`;
     rendered += renderIE(elementJSON.interactive_example_url);
     rendered += `${elementJSON.prose.overview}\n`;
-    rendered += renderAttributes(elementJSON.attributes);
+    rendered += renderAttributes(elementJSON.prose['attributes-text'], elementJSON.attributes);
+    rendered += `${elementJSON.prose['usage-notes']}\n`;
+    for (let section of elementJSON.prose['additional-sections']) {
+        rendered += `${section}\n`;
+    }
+    rendered += `<h2>Accessibility concerns</h2>\n${elementJSON.prose['accessibility-concerns']}\n`;
     rendered += renderExamples(elementJSON.examples);
+    rendered += `<h2>See also</h2>\n${elementJSON.prose['see-also']}\n`;
     rendered += '</body></html>';
 
     writeToFile(elementName, rendered);

--- a/scripts/render-html/render-ie.js
+++ b/scripts/render-html/render-ie.js
@@ -1,0 +1,7 @@
+function renderIE(url) {
+    return `<div><iframe class="interactive tabbed-standard" frameborder="0" height="450" src="${url}" width="100%"></iframe></div>`;
+}
+
+module.exports = {
+    renderIE
+}


### PR DESCRIPTION
For this sprint I'm working on some bits of https://github.com/mdn/sprints/issues/1638: writing some code to render MDN pages out of stumptown JSON.

I don't think the rendering code should live in this repo actually, so I really just filed this PR as a way to make it possible for people to try out the code and think about where we could house it best.

I did look at integrating it into https://github.com/peterbe/mdn2, but (a) that looked pretty complicated to me and (b) it looks like it needs some polish before being very contributor-friendly. But I'd be very happy to have a go at rehousing this code there if @peterbe can help me understand where to put it.

The only thing I really care about is for it to be modular, so it's easy to write code to render different bits of the page (e.g. compat tables, examples, etc) and drop them in.

In this version I'm basically following the pattern of build-json, where there's a single entry point that assembles a document out of pieces, and separate modules for each nontrivial piece.

So to run it:

* from a fresh checkout, first build the json: `npm run build-json html`
* then render it to static HTML: `npm run render-html video`

...it writes the file to ./rendered/html/elements/video.html and you can open it in a browser and it looks a bit like an MDN page with no CSS.

At the moment it includes:

* some prose sections (short descriptions, overview)
* interactive example
* attributes list (but not including possible values yet)
* live samples (using `srcdoc`, which I think will not work for CSS, but perhaps `src="data:..."` will?)

One tiny thing that makes me very happy: in the [MDN video page, the attributes list](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#Attributes) is not properly ordered. Bad news if you are looking for `preload`! In this version, not only is it properly ordered, but it will *always* be properly ordered, without anyone having to think about it. For me this kind of thing is a big part of the motivation for this project.

