### PR TITLE
Fix bug in attribute value parsing

### DIFF
--- a/scripts/build-json/compose-attributes.js
+++ b/scripts/build-json/compose-attributes.js
@@ -9,10 +9,10 @@ const bcd = require('mdn-browser-compat-data');
 
 const { JSDOM } = jsdom;
 
-function extractFromSiblings(node, terminatorTag, contentType) {
+function extractFromSiblings(node, terminatorTags, contentType) {
     let content = '';
     let sib = node.nextSibling;
-    while (sib && sib.nodeName != terminatorTag) {
+    while (sib && !terminatorTags.includes(sib.nodeName)) {
         if (sib.outerHTML) {
             if (contentType === 'html') {
                 content += sib.outerHTML;
@@ -31,7 +31,7 @@ function packageValues(heading, dom) {
     for (let valueHeading of valueHeadings) {
         let value = {
             value: valueHeading.textContent,
-            description: extractFromSiblings(valueHeading, 'H3', 'html')
+            description: extractFromSiblings(valueHeading, ['H2', 'H3'], 'html')
         }
         values.push(value);
     }
@@ -49,7 +49,7 @@ function packageAttribute(attributePath) {
     attribute.name = name.textContent;
 
     // extract the description property
-    attribute.description = extractFromSiblings(name, 'H2', 'html');
+    attribute.description = extractFromSiblings(name, ['H2'], 'html');
 
     // extract the type property
     const h2Headings = dom.querySelectorAll('h2');

--- a/scripts/build-json/slice-prose.js
+++ b/scripts/build-json/slice-prose.js
@@ -34,19 +34,6 @@ function extractFromSiblings(node, terminatorTag, contentType) {
     return content;
 }
 
-function packageValues(heading, dom) {
-    const values = [];
-    const valueHeadings = dom.querySelectorAll('h3');
-    for (let valueHeading of valueHeadings) {
-        let value = {
-            value: valueHeading.textContent,
-            description: extractFromSiblings(valueHeading, 'H3', 'html')
-        }
-        values.push(value);
-    }
-    return values;
-}
-
 function getSection(node, sections) {
     const sectionName = node.textContent.trim();
     const sectionContent = extractFromSiblings(node, '#comment', 'html');


### PR DESCRIPTION
The code in [compose-attributes](https://github.com/mdn/stumptown-experiment/blob/master/scripts/build-json/compose-attributes.js) is supposed to parse HTML attributes from the Markdown source into a JSON structure.

Among other things it tries to parse out attribute values, which are separated by H3 headings in the source. To do this it starts at the start and collects markup until it finds a tag that tells it to stop. In the old code this finishing tag was "H3", which works fine until the value is the last one, because then the next heading tag is the H2 for the attribute type, which then mistakenly gets swept up into the value description.

This change simply lets the client pass an array of tags, and we stop when any of them are encountered.

I've verified that with this fix, mdn2 renders attributes properly.

This PR also removes an unused copy of the function from slice-prose. 