### PR TITLE
Use headings rather than comments to demarcate prose sections

### DIFF
--- a/content/html/elements/video/prose.md
+++ b/content/html/elements/video/prose.md
@@ -1,7 +1,10 @@
-<!-- short-description -->
+## Short description
+
 The **HTML Video element** (**`<video>`**) embeds a media player which
 supports video playback into the document.
-<!-- overview -->
+
+## Overview
+
 You can use `<video>` for audio content as well, but the [`<audio>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio)
 element may provide a more appropriate user experience.
 
@@ -51,9 +54,8 @@ A good general source of information on using HTML `<video>` is the
 [Video and audio
 content](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content)
 beginner's tutorial.
-<!-- usage-notes -->
-Usage notes
------------
+
+## Usage notes
 
 ### Styling with CSS
 
@@ -151,9 +153,7 @@ setting](https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API#Cue_setting
 - [Understanding Success Criterion 1.2.2 | W3C Understanding WCAG
   2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/media-equiv-captions.html)
 
-<!-- see-also -->
-See also
---------
+## See also
 
 - [Media formats supported by the audio and video
   elements](https://developer.mozilla.org/en-US/docs/Media_formats_supported_by_the_audio_and_video_elements)
@@ -166,4 +166,3 @@ See also
   canvas](https://developer.mozilla.org/en-US/docs/Manipulating_video_using_canvas)
 - [Configuring servers for Ogg
   media](https://developer.mozilla.org/en-US/docs/Configuring_servers_for_Ogg_media)
-<!-- </see-also> -->

--- a/recipes/html-element.yaml
+++ b/recipes/html-element.yaml
@@ -1,16 +1,16 @@
 body:
-- prose.short-description
-- meta.interactive-example?
+- prose.short_description
+- meta.interactive_example?
 - prose.overview?
-- prose.attributes-text?
+- prose.attributes_text?
 - meta.attributes
-- prose.usage-notes
+- prose.usage_notes
 - prose.*
-- prose.accessibility-concerns?
+- prose.accessibility_concerns?
 - meta.examples
-- meta.info-box:
+- meta.info_box:
     - meta.api
-    - meta.permitted-aria-roles
+    - meta.permitted_aria_roles
     - meta.tag_omission
-- meta.browser-compatibility
-- prose.see-also
+- meta.browser_compatibility
+- prose.see_also

--- a/scripts/build-json/slice-prose.js
+++ b/scripts/build-json/slice-prose.js
@@ -10,13 +10,17 @@ const bcd = require('mdn-browser-compat-data');
 const { JSDOM } = jsdom;
 const commentNode = 8;
 const namedSections = [
-  'short-description',
-  'overview',
-  'attributes-text',
-  'usage-notes',
-  'accessibility-concerns',
-  'see-also'
+  'Short description',
+  'Overview',
+  'Attributes',
+  'Usage notes',
+  'Accessibility concerns',
+  'See also'
 ];
+
+function sectionNameToSlug(sectionName) {
+    return sectionName.toLowerCase().replace(' ', '_');
+}
 
 function extractFromSiblings(node, terminatorTag, contentType) {
     let content = '';
@@ -49,14 +53,18 @@ function packageValues(heading, dom) {
 
 function getSection(node, sections) {
     const sectionName = node.textContent.trim();
-    const sectionContent = extractFromSiblings(node, '#comment', 'html');
+    const sectionContent = extractFromSiblings(node, 'H2', 'html');
     const extraSections = [];
 
     if (namedSections.includes(sectionName)) {
-        sections[sectionName] = sectionContent;
+        const sectionSlug = sectionNameToSlug(sectionName);
+        sections[sectionSlug] = {
+            title: sectionName,
+            content: sectionContent
+        }
     } else {
         const additionalSection = {
-            name: sectionName,
+            title: sectionName,
             content: sectionContent
         };
       sections['additional-sections'].push(additionalSection);
@@ -71,7 +79,7 @@ function package(prosePath) {
     };
     let node = dom.firstChild;
     while (node) {
-        if (node.nodeType === commentNode) {
+        if (node.nodeName === 'H2') {
             getSection(node, sections);
         }
         node = node.nextSibling;


### PR DESCRIPTION
This implements a new way of demarcating sections in prose.md, along the lines of https://github.com/mdn/stumptown-experiment/issues/19.

* update video's prose.md to use just H2 headings to mark top-level sections
* update the JSON builder code to understand that and to emit title and content separately, like:

```
"short_description": {
    "title": "Short description",
    "content": "<p>The <strong>HTML Video element</strong> (<strong><code>&lt;video&gt;</code></strong>) embeds a media player which\nsupports video playback into the document.</p>"
},
```

Because this changes the JSON it'll break mdn2: I'll file a separate PR to fix that.

It doesn't yet implement "registration" for prose.* sections, but anyway video doesn't have any so we don't need it yet.

It also updates the recipe to use only "_" as a space-replacement.
