### PR TITLE
Lint markdown files; adjust headings

### DIFF
--- a/content/css/properties/border-block-start-width/prose.md
+++ b/content/css/properties/border-block-start-width/prose.md
@@ -1,13 +1,13 @@
-<!-- <short-description> -->
+## Short description
+
 The **`border-block-start-width`** [CSS](/en-US/docs/Web/CSS)
 property defines the width of the logical block-start border of an
 element, which maps to a physical border width depending on the
 element's writing mode, directionality, and text orientation.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-It
-corresponds to the
+## Overview
+
+It corresponds to the
 [`border-top-width`](/en-US/docs/Web/CSS/border-top-width),
 [`border-right-width`](/en-US/docs/Web/CSS/border-right-width),
 [`border-bottom-width`](/en-US/docs/Web/CSS/border-bottom-width),
@@ -18,33 +18,31 @@ property depending on the values defined for
 [`direction`](/en-US/docs/Web/CSS/direction),
 and
 [`text-orientation`](/en-US/docs/Web/CSS/text-orientation).
-<!-- </overview> -->
 
-<!-- <example-syntax> -->
+## Example syntax
 ```
 /* <'border-width'> values */
 border-block-start-width: 5px;
 border-block-start-width: thick;
 ```
-<!-- </example-syntax> -->
 
-<!-- <syntax-overview> -->
+## Syntax overview
 Related properties are
 [`border-block-end-width`](/en-US/docs/Web/CSS/border-block-end-width),
 [`border-inline-start-width`](/en-US/docs/Web/CSS/border-inline-start-width),
 and
 [`border-inline-end-width`](/en-US/docs/Web/CSS/border-inline-end-width),
 which define the other border widths of the element.
-<!-- </syntax-overview> -->
 
-<!-- <see-also> -->
--   This property maps to one of the physical border properties:
-    [`border-top-width`](/en-US/docs/Web/CSS/border-top-width),
-    [`border-right-width`](/en-US/docs/Web/CSS/border-right-width),
-    [`border-bottom-width`](/en-US/docs/Web/CSS/border-bottom-width),
-    and
-    [`border-left-width`](/en-US/docs/Web/CSS/border-left-width)
--   [`writing-mode`](/en-US/docs/Web/CSS/writing-mode),
-    [`direction`](/en-US/docs/Web/CSS/direction),
-    [`text-orientation`](/en-US/docs/Web/CSS/text-orientation)
-<!-- </see-also> -->
+
+## See also
+
+- This property maps to one of the physical border properties:
+  [`border-top-width`](/en-US/docs/Web/CSS/border-top-width),
+  [`border-right-width`](/en-US/docs/Web/CSS/border-right-width),
+  [`border-bottom-width`](/en-US/docs/Web/CSS/border-bottom-width),
+  and
+  [`border-left-width`](/en-US/docs/Web/CSS/border-left-width)
+- [`writing-mode`](/en-US/docs/Web/CSS/writing-mode),
+  [`direction`](/en-US/docs/Web/CSS/direction),
+  [`text-orientation`](/en-US/docs/Web/CSS/text-orientation)

--- a/content/css/properties/border-block-start-width/values/border-top-width.md
+++ b/content/css/properties/border-block-start-width/values/border-top-width.md
@@ -1,5 +1,4 @@
-
-# border-top-width
+# `border-top-width`
 
 The width of the border.
 

--- a/content/css/properties/border/prose.md
+++ b/content/css/properties/border/prose.md
@@ -66,5 +66,3 @@ values listed below. The order of the values does not matter.
 
 The border will be invisible if its style is not defined. This
 is because the style defaults to `none`.
-
-## See also

--- a/content/css/properties/border/prose.md
+++ b/content/css/properties/border/prose.md
@@ -1,9 +1,10 @@
-<!-- <short-description> -->
+## Short description
+
 The **`border`** [CSS](/en-US/docs/CSS) property sets an element's
 border.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
+
 It's a [shorthand](/en-US/docs/Web/CSS/Shorthand_properties)
 for [`border-width`](/en-US/docs/Web/CSS/border-width),
 [`border-style`](/en-US/docs/Web/CSS/border-style),
@@ -34,13 +35,12 @@ border properties.
 Borders and [outlines](/en-US/docs/Web/CSS/outline) are very similar.
 However, outlines differ from borders in the following ways:
 
--   Outlines never take up space, as they are drawn outside of an
-    element's content.
--   According to the spec, outlines don't have to be rectangular,
-    although they usually are.
-<!-- </overview> -->
+- Outlines never take up space, as they are drawn outside of an
+  element's content.
+- According to the spec, outlines don't have to be rectangular,
+  although they usually are.
 
-<!-- <example-syntax> -->
+## Example syntax
 ```.css
 /* style */
 border: solid;
@@ -59,15 +59,12 @@ border: inherit;
 border: initial;
 border: unset;
 ```
-<!-- </example-syntax> -->
 
-<!-- <syntax-overview> -->
+## Syntax overview
 The `border` property may be specified using one, two, or three of the
 values listed below. The order of the values does not matter.
 
 The border will be invisible if its style is not defined. This
 is because the style defaults to `none`.
-<!-- </syntax-overview> -->
 
-<!-- <see-also> -->
-<!-- </see-also> -->
+## See also

--- a/content/css/properties/border/values/color.md
+++ b/content/css/properties/border/values/color.md
@@ -1,5 +1,4 @@
-
-# color
+# `color`
 
 Sets the color of the border. Defaults to `currentcolor` if absent.
 

--- a/content/css/properties/border/values/line-style.md
+++ b/content/css/properties/border/values/line-style.md
@@ -1,5 +1,4 @@
-
-# line-style
+# `line-style`
 
 Sets the style of the border. Defaults to `none` if absent. See
 [`border-style`](/en-US/docs/Web/CSS/border-style).

--- a/content/css/properties/border/values/line-width.md
+++ b/content/css/properties/border/values/line-width.md
@@ -1,5 +1,4 @@
-
-# line-width
+# `line-width`
 
 Sets the thickness of the border. Defaults to `medium` if absent.
 See [`border-width`](/en-US/docs/Web/CSS/border-width).

--- a/content/css/properties/transform/prose.md
+++ b/content/css/properties/transform/prose.md
@@ -1,9 +1,10 @@
-<!-- <short-description> -->
+## Short description
+
 The **`transform`** [CSS](/en-US/docs/Web/CSS) property lets you rotate,
 scale, skew, or translate an element.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
+
 This property modifies the coordinate space
 of the CSS [visual formatting
 model](/en-US/docs/Web/CSS/Visual_formatting_model).
@@ -17,9 +18,9 @@ Only elements positioned by the [box
 model](/en-US/docs/Web/CSS/CSS_Box_Model) can be `transform`ed. As a
 rule of thumb, an element is positioned by the box model if it has
 `display: block`.
-<!-- </overview> -->
 
-<!-- <example-syntax> -->
+## Example syntax
+
 ```.css
 /* Keyword values */
 transform: none;
@@ -55,14 +56,12 @@ transform: inherit;
 transform: initial;
 transform: unset;
 ```
-<!-- </example-syntax> -->
 
-<!-- <syntax-overview> -->
+## Syntax overview
+
 The `transform` property may be specified as either the keyword value
 `none` or as one or more `<transform-function>` values.
-<!-- </syntax-overview> -->
 
-<!-- <see-also> -->
--   [Using CSS transforms](/en-US/docs/CSS/Using_CSS_transforms)
--   [`<transform-function>`](/en-US/docs/Web/CSS/transform-function) data type
-<!-- </see-also> -->
+## See also
+- [Using CSS transforms](/en-US/docs/CSS/Using_CSS_transforms)
+- [`<transform-function>`](/en-US/docs/Web/CSS/transform-function) data type

--- a/content/css/properties/transform/values/none.md
+++ b/content/css/properties/transform/values/none.md
@@ -1,8 +1,7 @@
-
-# none
+# `none`
 
 Specifies that no transform should be applied.
 
 ## Type
 
-Keyword
+`Keyword`

--- a/content/css/properties/transform/values/transform-function.md
+++ b/content/css/properties/transform/values/transform-function.md
@@ -1,8 +1,6 @@
+# `transform-function`
 
-# transform-function
-
-One or more of the [CSS transform
-functions](/en-US/docs/Web/CSS/transform-function) to be applied.
+One or more of the [CSS transform functions](/en-US/docs/Web/CSS/transform-function) to be applied.
 The transform functions are multiplied in order from left to right,
 meaning that composite transforms are effectively applied in order
 from right to left.

--- a/content/html/elements/abbr/prose.md
+++ b/content/html/elements/abbr/prose.md
@@ -1,9 +1,9 @@
-<!-- short-description -->
+## Short description
+
 The **HTML Abbreviation element** (**`<abbr>`**) represents an
 abbreviation or acronym.
-<!-- <usage-notes> -->
-Usage notes
------------
+
+## Usage notes
 
 The article *[How to mark abbreviations and make them
 understandable](/en-US/Learn/HTML/Howto/Mark_abbreviations_and_make_them_understandable)*
@@ -14,19 +14,19 @@ is a guide to learning to use `<abbr>` and related elements.
 It's certainly not required that all abbreviations be marked up using
 `<abbr>`. There are, though, a few cases where it's helpful to do so:
 
--   When an abbreviation is used and you want to provide an expansion or
-    definition outside the flow of the document's content, use `<abbr>`
-    with an appropriate `title`.
--   To define an abbreviation which may be unfamiliar to the reader,
-    present the term using `<abbr>` and either a `title` attribute or
-    inline text providing the definition.
--   When an abbreviation's presence in the text needs to be
-    semantically noted, the `<abbr>` element is useful. This can be
-    used, in turn, for styling or scripting purposes.
--   You can use `<abbr>` in concert with
-    [`<dfn>`](/en-US/docs/Web/HTML/Element/dfn)
-    to establish definitions for terms which are abbreviations or
-    acronyms. See the example [Defining an abbreviation](#Defining_an_abbreviation) below.
+- When an abbreviation is used and you want to provide an expansion or
+  definition outside the flow of the document's content, use `<abbr>`
+  with an appropriate `title`.
+- To define an abbreviation which may be unfamiliar to the reader,
+  present the term using `<abbr>` and either a `title` attribute or
+  inline text providing the definition.
+- When an abbreviation's presence in the text needs to be
+  semantically noted, the `<abbr>` element is useful. This can be
+  used, in turn, for styling or scripting purposes.
+- You can use `<abbr>` in concert with
+  [`<dfn>`](/en-US/docs/Web/HTML/Element/dfn)
+  to establish definitions for terms which are abbreviations or
+  acronyms. See the example [Defining an abbreviation](#Defining_an_abbreviation) below.
 
 ### Grammar considerations
 
@@ -43,7 +43,9 @@ English.
 The optional `title` attribute can provide an
 expansion or description for the abbreviation. If present,
 `title` must contain this full description and nothing else.
-<!-- accessibility-concerns -->
+
+## Accessibility concerns
+
 Spelling out the acronym or abbreviation in full the first time it is
 used on a page is beneficial for helping people understand it,
 especially if the content is technical or industry jargon.
@@ -57,7 +59,9 @@ especially if the content is technical or industry jargon.
 This is especially helpful for people who are unfamiliar with the
 terminology or concepts discussed in the content, people who are new to
 the language, and people with cognitive concerns.
-<!-- attributes-text -->
+
+## Attributes text
+
 The `title`
 attribute has a specific semantic meaning when used with the `<abbr>`
 element; it *must* contain a full human-readable description or
@@ -67,9 +71,8 @@ as a tooltip when the mouse cursor is hovered over the element.
 Each `<abbr>` element you use is independent from all others; providing
 a `title` for one does not automatically attach the same expansion text
 to others with the same content text.
-<!-- default-styling -->
-Default styling
----------------
+
+## Default styling
 
 The purpose of this element is purely for the convenience of the author
 and all browsers display it inline
@@ -77,43 +80,45 @@ and all browsers display it inline
 by default, though its default styling varies from one browser to
 another:
 
--   Some browsers, like Internet Explorer, do not style it differently
-    than a
-    [`<span>`](/en-US/docs/Web/HTML/Element/span)
-    element.
--   Opera, Firefox, and some others add a dotted underline to the
-    content of the element.
--   A few browsers not only add a dotted underline, but also put it in
-    small caps; to avoid this styling, adding something like
-    [`font-variant`](/en-US/docs/Web/CSS/font-variant)`: none`
-    in the CSS takes care of this case.
-<!-- see-also -->
--   [Using the `<abbr>` element](/en-US/Learn/HTML/Element/abbr)
--   Other elements conveying [text-level semantics](/en-US/docs/Web/HTML/Text_level_semantics_conveying_elements):
-    [`<a>`](/en-US/docs/Web/HTML/Element/a),
-    [`<em>`](/en-US/docs/Web/HTML/Element/em),
-    [`<strong>`](/en-US/docs/Web/HTML/Element/strong),
-    [`<small>`](/en-US/docs/Web/HTML/Element/small),
-    [`<cite>`](/en-US/docs/Web/HTML/Element/cite),
-    [`<q>`](/en-US/docs/Web/HTML/Element/q),
-    [`<dfn>`](/en-US/docs/Web/HTML/Element/dfn),
-    [`<time>`](/en-US/docs/Web/HTML/Element/time),
-    [`<code>`](/en-US/docs/Web/HTML/Element/code),
-    [`<var>`](/en-US/docs/Web/HTML/Element/var),
-    [`<samp>`](/en-US/docs/Web/HTML/Element/samp),
-    [`<kbd>`](/en-US/docs/Web/HTML/Element/kbd),
-    [`<sub>`](/en-US/docs/Web/HTML/Element/sub),
-    [`<sup>`](/en-US/docs/Web/HTML/Element/sup),
-    [`<b>`](/en-US/docs/Web/HTML/Element/b),
-    [`<i>`](/en-US/docs/Web/HTML/Element/i),
-    [`<mark>`](/en-US/docs/Web/HTML/Element/mark),
-    [`<ruby>`](/en-US/docs/Web/HTML/Element/ruby),
-    [`<rp>`](/en-US/docs/Web/HTML/Element/rp),
-    [`<rt>`](/en-US/docs/Web/HTML/Element/rt),
-    [`<bdo>`](/en-US/docs/Web/HTML/Element/bdo),
-    [`<span>`](/en-US/docs/Web/HTML/Element/span),
-    [`<br>`](/en-US/docs/Web/HTML/Element/br),
-    [`<wbr>`](/en-US/docs/Web/HTML/Element/wbr).
--   The obsolete
-    [`<acronym>`](/en-US/docs/Web/HTML/Element/acronym)
-    element, whose responsibilities were folded into `<abbr>`
+- Some browsers, like Internet Explorer, do not style it differently
+  than a
+  [`<span>`](/en-US/docs/Web/HTML/Element/span)
+  element.
+- Opera, Firefox, and some others add a dotted underline to the
+  content of the element.
+- A few browsers not only add a dotted underline, but also put it in
+  small caps; to avoid this styling, adding something like
+  [`font-variant`](/en-US/docs/Web/CSS/font-variant)`: none`
+  in the CSS takes care of this case.
+
+## See also
+
+- [Using the `<abbr>` element](/en-US/Learn/HTML/Element/abbr)
+- Other elements conveying [text-level semantics](/en-US/docs/Web/HTML/Text_level_semantics_conveying_elements):
+  [`<a>`](/en-US/docs/Web/HTML/Element/a),
+  [`<em>`](/en-US/docs/Web/HTML/Element/em),
+  [`<strong>`](/en-US/docs/Web/HTML/Element/strong),
+  [`<small>`](/en-US/docs/Web/HTML/Element/small),
+  [`<cite>`](/en-US/docs/Web/HTML/Element/cite),
+  [`<q>`](/en-US/docs/Web/HTML/Element/q),
+  [`<dfn>`](/en-US/docs/Web/HTML/Element/dfn),
+  [`<time>`](/en-US/docs/Web/HTML/Element/time),
+  [`<code>`](/en-US/docs/Web/HTML/Element/code),
+  [`<var>`](/en-US/docs/Web/HTML/Element/var),
+  [`<samp>`](/en-US/docs/Web/HTML/Element/samp),
+  [`<kbd>`](/en-US/docs/Web/HTML/Element/kbd),
+  [`<sub>`](/en-US/docs/Web/HTML/Element/sub),
+  [`<sup>`](/en-US/docs/Web/HTML/Element/sup),
+  [`<b>`](/en-US/docs/Web/HTML/Element/b),
+  [`<i>`](/en-US/docs/Web/HTML/Element/i),
+  [`<mark>`](/en-US/docs/Web/HTML/Element/mark),
+  [`<ruby>`](/en-US/docs/Web/HTML/Element/ruby),
+  [`<rp>`](/en-US/docs/Web/HTML/Element/rp),
+  [`<rt>`](/en-US/docs/Web/HTML/Element/rt),
+  [`<bdo>`](/en-US/docs/Web/HTML/Element/bdo),
+  [`<span>`](/en-US/docs/Web/HTML/Element/span),
+  [`<br>`](/en-US/docs/Web/HTML/Element/br),
+  [`<wbr>`](/en-US/docs/Web/HTML/Element/wbr).
+- The obsolete
+  [`<acronym>`](/en-US/docs/Web/HTML/Element/acronym)
+  element, whose responsibilities were folded into `<abbr>`

--- a/content/html/elements/address/prose.md
+++ b/content/html/elements/address/prose.md
@@ -1,10 +1,11 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<address>` element** indicates that the enclosed HTML
 provides contact information for a person or people, or for an
 organization.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
+
 The contact information provided by an `<address>` element\'s contents
 can take whatever form is appropriate for the context, and may include
 any type of contact information that is needed, such as physical
@@ -17,45 +18,36 @@ contact information refers.
 business\'s contact information in the page header, or indicating the
 author of an article by including an `<address>` element within the
 [`<article>`](/en-US/docs/Web/HTML/Element/article "The HTML <article> element represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e.g., in syndication). Examples include: a forum post, a magazine or newspaper article, or a blog entry.").
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Usage notes
 
--   To represent an arbitrary address, one that is not related to the
-    contact information, use a
-    [`<p>`](/en-US/docs/Web/HTML/Element/p)
-    element rather than the `<address>` element.
--   This element should not contain more information than the contact
-    information, like a publication date (which belongs in a
-    [`<time>`](/en-US/docs/Web/HTML/Element/time)
-    element).
--   Typically an `<address>` element can be placed inside the
-    [`<footer>`](/en-US/docs/Web/HTML/Element/footer)
-    element of the current section, if any.
+- To represent an arbitrary address, one that is not related to the
+  contact information, use a
+  [`<p>`](/en-US/docs/Web/HTML/Element/p)
+  element rather than the `<address>` element.
+- This element should not contain more information than the contact
+  information, like a publication date (which belongs in a
+  [`<time>`](/en-US/docs/Web/HTML/Element/time)
+  element).
+- Typically an `<address>` element can be placed inside the
+  [`<footer>`](/en-US/docs/Web/HTML/Element/footer)
+  element of the current section, if any.
 
-<!-- </usage-notes> -->
+## See also
 
-<!-- <see-also> -->
-See also
---------
-
--   Others section-related elements:
-    [`<body>`](/en-US/docs/Web/HTML/Element/body),
-    [`<nav>`](/en-US/docs/Web/HTML/Element/nav),
-    [`<article>`](/en-US/docs/Web/HTML/Element/article),
-    [`<aside>`](/en-US/docs/Web/HTML/Element/aside),
-    [`<h1>`](/en-US/docs/Web/HTML/Element/h1),
-    [`<h2>`](/en-US/docs/Web/HTML/Element/h2),
-    [`<h3>`](/en-US/docs/Web/HTML/Element/h3),
-    [`<h4>`](/en-US/docs/Web/HTML/Element/h4),
-    [`<h5>`](/en-US/docs/Web/HTML/Element/h5),
-    [`<h6>`](/en-US/docs/Web/HTML/Element/h6),
-    [`<hgroup>`](/en-US/docs/Web/HTML/Element/hgroup),
-    [`<footer>`](/en-US/docs/Web/HTML/Element/footer),
-    [`<section>`](/en-US/docs/Web/HTML/Element/section),
-    [`<header>`](/en-US/docs/Web/HTML/Element/header);
--   [Sections and outlines of an HTML5 document](/en-US/docs/Sections_and_Outlines_of_an_HTML5_document).
-
-<!-- </see-also> -->
+- Others section-related elements:
+  [`<body>`](/en-US/docs/Web/HTML/Element/body),
+  [`<nav>`](/en-US/docs/Web/HTML/Element/nav),
+  [`<article>`](/en-US/docs/Web/HTML/Element/article),
+  [`<aside>`](/en-US/docs/Web/HTML/Element/aside),
+  [`<h1>`](/en-US/docs/Web/HTML/Element/h1),
+  [`<h2>`](/en-US/docs/Web/HTML/Element/h2),
+  [`<h3>`](/en-US/docs/Web/HTML/Element/h3),
+  [`<h4>`](/en-US/docs/Web/HTML/Element/h4),
+  [`<h5>`](/en-US/docs/Web/HTML/Element/h5),
+  [`<h6>`](/en-US/docs/Web/HTML/Element/h6),
+  [`<hgroup>`](/en-US/docs/Web/HTML/Element/hgroup),
+  [`<footer>`](/en-US/docs/Web/HTML/Element/footer),
+  [`<section>`](/en-US/docs/Web/HTML/Element/section),
+  [`<header>`](/en-US/docs/Web/HTML/Element/header);
+- [Sections and outlines of an HTML5 document](/en-US/docs/Sections_and_Outlines_of_an_HTML5_document).

--- a/content/html/elements/article/prose.md
+++ b/content/html/elements/article/prose.md
@@ -1,20 +1,18 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<article>` element** represents a self-contained composition
 in a document, page, application, or site, which is intended to be
 independently distributable or reusable (e.g., in syndication). Examples
 include: a forum post, a magazine or newspaper article, or a blog entry.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
+
 A given document can have multiple articles in it; for example, on a
 blog that shows the text of each article one after another as the reader
 scrolls, each post would be contained in an `<article>` element,
 possibly with one or more `<section>`s within.
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Usage notes
 
 - Each `<article>` should be identified, typically by including a heading
   ([`<h1>`-`<h6>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements)
@@ -32,11 +30,9 @@ Usage notes
   element. Note that the `pubdate` attribute of
   [`<time>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time)
   is no longer a part of the W3C HTML 5 standard.
-<!-- </usage-notes> -->
 
-<!-- <see-also> -->
-See also
---------
+
+## See also
 
 - Other section-related elements:
   [`<body>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body),
@@ -54,5 +50,3 @@ See also
   [`<footer>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer),
   [`<address>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address)
 - [Sections and outlines of an HTML5 document](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Sections_and_Outlines_of_an_HTML5_document)
-
-<!-- </see-also> -->

--- a/content/html/elements/aside/prose.md
+++ b/content/html/elements/aside/prose.md
@@ -1,44 +1,33 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<aside>` element** represents a portion of a document whose
 content is only indirectly related to the document's main
 content. Asides are frequently presented as sidebars or
 call-out boxes.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Usage notes
 
--   Do not use the `<aside>` element to tag parenthesized text, as this
-    kind of text is considered part of the main flow.
+- Do not use the `<aside>` element to tag parenthesized text, as this
+  kind of text is considered part of the main flow.
 
-<!-- </usage-notes> -->
+## See also
 
-<!-- <see-also> -->
-See also
---------
-
--   Others section-related elements:
-    [`<body>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/body),
-    [`<article>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/article). Examples include: a forum post, a magazine or newspaper article, or a blog entry."),
-    [`<section>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/section),
-    [`<nav>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/nav),
-    [`<h1>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/h1),
-    [`<h2>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/h2),
-    [`<h3>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/h3),
-    [`<h4>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/h4),
-    [`<h5>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/h5),
-    [`<h6>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/h6),
-    [`<hgroup>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/hgroup),
-    [`<header>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/header),
-    [`<footer>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/footer),
-    [`<address>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/address);
--   [Sections and outlines of an HTML5
-    document](https://developer.mozilla.org/en-US/docsdocs/Sections_and_Outlines_of_an_HTML5_document).
--   [ARIA: Complementary
-    role](https://developer.mozilla.org/en-US/docsdocs/Web/Accessibility/ARIA/ARIA_Techniques/Complementary_role)
-
-<!-- </see-also> -->
+- Others section-related elements:
+  [`<body>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/body),
+  [`<article>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/article). Examples include: a forum post, a magazine or newspaper article, or a blog entry."),
+  [`<section>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/section),
+  [`<nav>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/nav),
+  [`<h1>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/h1),
+  [`<h2>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/h2),
+  [`<h3>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/h3),
+  [`<h4>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/h4),
+  [`<h5>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/h5),
+  [`<h6>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/h6),
+  [`<hgroup>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/hgroup),
+  [`<header>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/header),
+  [`<footer>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/footer),
+  [`<address>`](https://developer.mozilla.org/en-US/docsdocs/Web/HTML/Element/address);
+- [Sections and outlines of an HTML5 document](https://developer.mozilla.org/en-US/docsdocs/Sections_and_Outlines_of_an_HTML5_document).
+- [ARIA: Complementary role](https://developer.mozilla.org/en-US/docsdocs/Web/Accessibility/ARIA/ARIA_Techniques/Complementary_role)

--- a/content/html/elements/aside/prose.md
+++ b/content/html/elements/aside/prose.md
@@ -5,8 +5,6 @@ content is only indirectly related to the document's main
 content. Asides are frequently presented as sidebars or
 call-out boxes.
 
-## Overview
-
 ## Usage notes
 
 - Do not use the `<aside>` element to tag parenthesized text, as this

--- a/content/html/elements/audio/prose.md
+++ b/content/html/elements/audio/prose.md
@@ -1,4 +1,5 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<audio>` element** is used to embed sound content in
 documents. It may contain one or more audio sources, represented using
 the `src` attribute or the
@@ -6,9 +7,8 @@ the `src` attribute or the
 element: the browser will choose the most suitable one. It can also be
 the destination for streamed media, using a
 [`MediaStream`](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream).
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
 In a similar manner to the
 [`<img>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img)
 element, we include a path to the media we want to embed inside the
@@ -36,32 +36,28 @@ elements, and the browser will then use the first one it understands:
 
 Other usage notes:
 
--   If you don't specify the `controls` attribute, the audio player
-    won't include the browser's default controls; you can create your
-    own custom controls using JavaScript and the
-    [`HTMLMediaElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement)
-    API.
--   To allow precise control over your audio content,
-    `HTMLMediaElement`s fire many different
-    [events](https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Media_events).
--   You can also use the [Web Audio
-    API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API) to directly generate and
-    manipulate audio streams from JavaScript code.
--   `<audio>` elements can't have subtitles/captions associated with
-    them in the same way that `<video>` elements can. See [WebVTT and
-    Audio](https://www.iandevlin.com/blog/2015/12/html5/webvtt-and-audio)
-    by Ian Devlin for some useful information and workarounds.
+- If you don't specify the `controls` attribute, the audio player
+  won't include the browser's default controls; you can create your
+  own custom controls using JavaScript and the
+  [`HTMLMediaElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement)
+  API.
+- To allow precise control over your audio content,
+  `HTMLMediaElement`s fire many different
+  [events](https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Media_events).
+- You can also use the [Web Audio
+  API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API) to directly generate and
+  manipulate audio streams from JavaScript code.
+- `<audio>` elements can't have subtitles/captions associated with
+  them in the same way that `<video>` elements can. See [WebVTT and
+  Audio](https://www.iandevlin.com/blog/2015/12/html5/webvtt-and-audio)
+  by Ian Devlin for some useful information and workarounds.
 
 A good general source of information on using HTML `<audio>` is the
 [Video and audio
 content](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content)
 beginner's tutorial.
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-
-Usage notes
------------
+## Usage notes
 
 ### Styling with CSS
 
@@ -106,19 +102,19 @@ they\'re sent to the track list object within the `<audio>` element's
 [`HTMLMediaElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement)
 that corresponds to the type of track that was added to the element:
 
-*   [`HTMLMediaElement.audioTracks`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/audioTracks): An
-    [`AudioTrackList`](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrackList)
-    containing all of the media element's audio tracks. You can add a
-    listener for `addtrack` to this object to be alerted when new audio
-    tracks are added to the element.
+* [`HTMLMediaElement.audioTracks`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/audioTracks): An
+  [`AudioTrackList`](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrackList)
+  containing all of the media element's audio tracks. You can add a
+  listener for `addtrack` to this object to be alerted when new audio
+  tracks are added to the element.
 
-*   [`HTMLMediaElement.videoTracks`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/videoTracks): Add an `addtrack` listener to this
-    [`VideoTrackList`](https://developer.mozilla.org/en-US/docs/Web/API/VideoTrackList)
-    object to be informed when video tracks are added to the element.
+* [`HTMLMediaElement.videoTracks`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/videoTracks): Add an `addtrack` listener to this
+  [`VideoTrackList`](https://developer.mozilla.org/en-US/docs/Web/API/VideoTrackList)
+  object to be informed when video tracks are added to the element.
 
-*   [`HTMLElement.textTracks`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/textTracks): Add an `addtrack` event listener to this
-    [`TextTrackList`](https://developer.mozilla.org/en-US/docs/Web/API/TextTrackList)
-    to be notified when new text tracks are added to the element.
+* [`HTMLElement.textTracks`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/textTracks): Add an `addtrack` event listener to this
+  [`TextTrackList`](https://developer.mozilla.org/en-US/docs/Web/API/TextTrackList)
+  to be notified when new text tracks are added to the element.
 
 **Note:** Even though it's an `<audio>` element, it still has video and
 text track lists, and can in fact be used to present video, although the
@@ -146,9 +142,8 @@ and remove the track from the editor's list of available tracks.
 You can also use
 [`addEventListener()`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) to listen for the `addtrack` and `removetrack` events.
 
-<!-- </usage-notes> -->
+## Accessibility concerns
 
-<!-- <accessibility-concerns> -->
 Audio with spoken dialog should provide both captions and transcripts
 that accurately describe its content. Captions allow people who are
 experiencing hearing loss to understand an audio recording's content as
@@ -163,49 +158,35 @@ In addition to spoken dialog, subtitles and transcripts should also
 identify music and sound effects that communicate important information.
 This includes emotion and tone:
 
+```
     1
     00:00:00 --> 00:00:45
     [Energetic techno music]
 
-    2 
+    2
     00:00:46 --> 00:00:51
     Welcome to the Time Keeper's podcast! In this episode we're discussing which Swisswatch is a wrist switchwatch?
 
     16
     00:00:52 --> 00:01:02
     [Laughing] Sorry! I mean, which wristwatch is a Swiss wristwatch?
+```
 
--   [MDN Subtitles and closed caption ---
-    Plugins](https://developer.mozilla.org/en-US/docs/Plugins/Flash_to_HTML5/Video/Subtitles_captions)
--   [Web Video Text Tracks Format
-    (WebVTT)](https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API)
--   [WebAIM: Captions, Transcripts, and Audio
-    Descriptions](https://webaim.org/techniques/captions/)
--   [MDN Understanding WCAG, Guideline 1.2
-    explanations](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#Guideline_1.2_—_Providing_text_alternatives_for_time-based_media)
--   [Understanding Success Criterion 1.2.1 \| W3C Understanding WCAG
-    2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/media-equiv-av-only-alt.html)
--   [Understanding Success Criterion 1.2.2 \| W3C Understanding WCAG
-    2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/media-equiv-captions.html)
+- [MDN Subtitles and closed caption --- Plugins](https://developer.mozilla.org/en-US/docs/Plugins/Flash_to_HTML5/Video/Subtitles_captions)
+- [Web Video Text Tracks Format (WebVTT)](https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API)
+- [WebAIM: Captions, Transcripts, and Audio Descriptions](https://webaim.org/techniques/captions/)
+- [MDN Understanding WCAG, Guideline 1.2 explanations](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#Guideline_1.2_—_Providing_text_alternatives_for_time-based_media)
+- [Understanding Success Criterion 1.2.1 \| W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/media-equiv-av-only-alt.html)
+- [Understanding Success Criterion 1.2.2 \| W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/media-equiv-captions.html)
 
-<!-- </accessibility-concerns> -->
+## See also
 
-<!-- <see-also> -->
-
-See also
---------
-
--   [Media formats supported by the audio and video
-    elements](https://developer.mozilla.org/en-US/docs/Media_formats_supported_by_the_audio_and_video_elements)
--   [Web Audio API](https://developer.mozilla.org/en-US/docs/Web_Audio_API)
--   [`HTMLAudioElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAudioElement)
--   [`nsIDOMHTMLMediaElement`](https://developer.mozilla.org/en-US/docs/XPCOM_Interface_Reference/NsIDOMHTMLMediaElement)
--   [`<source>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source)
--   [`<video>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video)
--   [Using audio and video](https://developer.mozilla.org/en-US/docs/Using_HTML5_audio_and_video)
--   [Cross-browser audio
-    basics](https://developer.mozilla.org/en-US/docsApps/Fundamentals/Audio_and_video_delivery/Cross-browser_audio_basics)
--   [The `audio`
-    element](https://www.whatwg.org/specs/web-apps/current-work/#audio)
-    (HTML5 specification)
-<!-- </see-also> -->
+- [Media formats supported by the audio and video elements](https://developer.mozilla.org/en-US/docs/Media_formats_supported_by_the_audio_and_video_elements)
+- [Web Audio API](https://developer.mozilla.org/en-US/docs/Web_Audio_API)
+- [`HTMLAudioElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAudioElement)
+- [`nsIDOMHTMLMediaElement`](https://developer.mozilla.org/en-US/docs/XPCOM_Interface_Reference/NsIDOMHTMLMediaElement)
+- [`<source>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source)
+- [`<video>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video)
+- [Using audio and video](https://developer.mozilla.org/en-US/docs/Using_HTML5_audio_and_video)
+- [Cross-browser audio basics](https://developer.mozilla.org/en-US/docsApps/Fundamentals/Audio_and_video_delivery/Cross-browser_audio_basics)
+- [The `audio` element](https://www.whatwg.org/specs/web-apps/current-work/#audio) (HTML5 specification)

--- a/content/html/elements/b/prose.md
+++ b/content/html/elements/b/prose.md
@@ -1,10 +1,11 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML Bring Attention To element** (**`<b>`**) is used to draw the
 reader's attention to the element's contents, which are not otherwise
 granted special importance.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
+
 This was formerly known as the
 **Boldface element**, and most browsers still draw the text in boldface.
 However, you should not use `<b>` for styling text; instead, you should
@@ -13,81 +14,73 @@ use the CSS
 property to create boldface text, or the
 [`<strong>`](/en-US/docs/Web/HTML/Element/strong)
 element to indicate that text is of special importance.
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Usage notes
 
--   Use the `<b>` for cases like keywords in a summary, product names in
-    a review, or other spans of text whose typical presentation would be
-    boldfaced (but not including any special importance).
--   Do not confuse the `<b>` element with the
-    [`<strong>`](/en-US/docs/Web/HTML/Element/strong),
-    [`<em>`](/en-US/docs/Web/HTML/Element/em),
-    or
-    [`<mark>`](/en-US/docs/Web/HTML/Element/mark)
-    elements. The
-    [`<strong>`](/en-US/docs/Web/HTML/Element/strong)
-    element represents text of certain *importance*,
-    [`<em>`](/en-US/docs/Web/HTML/Element/em)
-    puts some emphasis on the text and the
-    [`<mark>`](/en-US/docs/Web/HTML/Element/mark)
-    element represents text of certain *relevance*. The `<b>` element
-    doesn't convey such special semantic information; use it only when
-    no others fit.
--   Similarly, do not mark titles and headings using the `<b>` element.
-    For this purpose, use the
-    [`<h1>`](/en-US/docs/Web/HTML/Element/h1)
-    to
-    [`<h6>`](/en-US/docs/Web/HTML/Element/h6)
-    tags. Further, stylesheets can change the default style of these
-    elements, with the result that they are not *necessarily* displayed
-    in bold.
--   It is a good practice to use the `class` attribute on the `<b>`
-    element in order to convey additional semantic information as needed
-    (for example `<b class="lead">` for the first sentence in a
-    paragraph). This makes it easier to manage multiple use cases of
-    `<b>` if your stylistic needs change, without the need to change all
-    of its uses in the HTML.
--   Historically, the `<b>` element was meant to make text boldface.
-    Styling information has been deprecated since HTML4, so the meaning
-    of the `<b>` element has been changed.
--   If there is no semantic purpose to using the `<b>` element, you
-    should use the CSS
-    [`font-weight`](/en-US/docs/Web/CSS/font-weight)
-    property with the value `"bold"` instead in order to make text bold.
-<!-- </usage-notes> -->
+- Use the `<b>` for cases like keywords in a summary, product names in
+  a review, or other spans of text whose typical presentation would be
+  boldfaced (but not including any special importance).
+- Do not confuse the `<b>` element with the
+  [`<strong>`](/en-US/docs/Web/HTML/Element/strong),
+  [`<em>`](/en-US/docs/Web/HTML/Element/em),
+  or
+  [`<mark>`](/en-US/docs/Web/HTML/Element/mark)
+  elements. The
+  [`<strong>`](/en-US/docs/Web/HTML/Element/strong)
+  element represents text of certain *importance*,
+  [`<em>`](/en-US/docs/Web/HTML/Element/em)
+  puts some emphasis on the text and the
+  [`<mark>`](/en-US/docs/Web/HTML/Element/mark)
+  element represents text of certain *relevance*. The `<b>` element
+  doesn't convey such special semantic information; use it only when
+  no others fit.
+- Similarly, do not mark titles and headings using the `<b>` element.
+  For this purpose, use the
+  [`<h1>`](/en-US/docs/Web/HTML/Element/h1)
+  to
+  [`<h6>`](/en-US/docs/Web/HTML/Element/h6)
+  tags. Further, stylesheets can change the default style of these
+  elements, with the result that they are not *necessarily* displayed
+  in bold.
+- It is a good practice to use the `class` attribute on the `<b>`
+  element in order to convey additional semantic information as needed
+  (for example `<b class="lead">` for the first sentence in a
+  paragraph). This makes it easier to manage multiple use cases of
+  `<b>` if your stylistic needs change, without the need to change all
+  of its uses in the HTML.
+- Historically, the `<b>` element was meant to make text boldface.
+  Styling information has been deprecated since HTML4, so the meaning
+  of the `<b>` element has been changed.
+- If there is no semantic purpose to using the `<b>` element, you
+  should use the CSS
+  [`font-weight`](/en-US/docs/Web/CSS/font-weight)
+  property with the value `"bold"` instead in order to make text bold.
 
-<!-- <see-also> -->
+## See also
 
-See also
---------
-
--   Others elements conveying [text-level semantics](/en-US/docs/HTML/Text_level_semantics_conveying_elements):
-    [`<a>`](/en-US/docs/Web/HTML/Element/a),
-    [`<em>`](/en-US/docs/Web/HTML/Element/em),
-    [`<strong>`](/en-US/docs/Web/HTML/Element/strong),
-    [`<small>`](/en-US/docs/Web/HTML/Element/small),
-    [`<cite>`](/en-US/docs/Web/HTML/Element/cite),
-    [`<q>`](/en-US/docs/Web/HTML/Element/q),
-    [`<dfn>`](/en-US/docs/Web/HTML/Element/dfn),
-    [`<abbr>`](/en-US/docs/Web/HTML/Element/abbr),
-    [`<time>`](/en-US/docs/Web/HTML/Element/time),
-    [`<code>`](/en-US/docs/Web/HTML/Element/code),
-    [`<var>`](/en-US/docs/Web/HTML/Element/var),
-    [`<samp>`](/en-US/docs/Web/HTML/Element/samp),
-    [`<kbd>`](/en-US/docs/Web/HTML/Element/kbd),
-    [`<sub>`](/en-US/docs/Web/HTML/Element/sub),
-    [`<sup>`](/en-US/docs/Web/HTML/Element/sup),
-    [`<i>`](/en-US/docs/Web/HTML/Element/i),
-    [`<mark>`](/en-US/docs/Web/HTML/Element/mark),
-    [`<ruby>`](/en-US/docs/Web/HTML/Element/ruby),
-    [`<rp>`](/en-US/docs/Web/HTML/Element/rp),
-    [`<rt>`](/en-US/docs/Web/HTML/Element/rt),
-    [`<bdo>`](/en-US/docs/Web/HTML/Element/bdo),
-    [`<span>`](/en-US/docs/Web/HTML/Element/span),
-    [`<br>`](/en-US/docs/Web/HTML/Element/br),
-    [`<wbr>`](/en-US/docs/Web/HTML/Element/wbr).
--   [Using \<b\> and \<i\> elements (W3C)](https://www.w3.org/International/questions/qa-b-and-i-tags)
-<!-- </see-also> -->
+- Others elements conveying [text-level semantics](/en-US/docs/HTML/Text_level_semantics_conveying_elements):
+  [`<a>`](/en-US/docs/Web/HTML/Element/a),
+  [`<em>`](/en-US/docs/Web/HTML/Element/em),
+  [`<strong>`](/en-US/docs/Web/HTML/Element/strong),
+  [`<small>`](/en-US/docs/Web/HTML/Element/small),
+  [`<cite>`](/en-US/docs/Web/HTML/Element/cite),
+  [`<q>`](/en-US/docs/Web/HTML/Element/q),
+  [`<dfn>`](/en-US/docs/Web/HTML/Element/dfn),
+  [`<abbr>`](/en-US/docs/Web/HTML/Element/abbr),
+  [`<time>`](/en-US/docs/Web/HTML/Element/time),
+  [`<code>`](/en-US/docs/Web/HTML/Element/code),
+  [`<var>`](/en-US/docs/Web/HTML/Element/var),
+  [`<samp>`](/en-US/docs/Web/HTML/Element/samp),
+  [`<kbd>`](/en-US/docs/Web/HTML/Element/kbd),
+  [`<sub>`](/en-US/docs/Web/HTML/Element/sub),
+  [`<sup>`](/en-US/docs/Web/HTML/Element/sup),
+  [`<i>`](/en-US/docs/Web/HTML/Element/i),
+  [`<mark>`](/en-US/docs/Web/HTML/Element/mark),
+  [`<ruby>`](/en-US/docs/Web/HTML/Element/ruby),
+  [`<rp>`](/en-US/docs/Web/HTML/Element/rp),
+  [`<rt>`](/en-US/docs/Web/HTML/Element/rt),
+  [`<bdo>`](/en-US/docs/Web/HTML/Element/bdo),
+  [`<span>`](/en-US/docs/Web/HTML/Element/span),
+  [`<br>`](/en-US/docs/Web/HTML/Element/br),
+  [`<wbr>`](/en-US/docs/Web/HTML/Element/wbr).
+- [Using \<b\> and \<i\> elements (W3C)](https://www.w3.org/International/questions/qa-b-and-i-tags)

--- a/content/html/elements/base/prose.md
+++ b/content/html/elements/base/prose.md
@@ -1,21 +1,17 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<base>` element** specifies the base URL to use for all
 relative URLs contained within a document. There can be only one
 `<base>` element in a document.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
+
 The base URL of a document can be queried from a script using
 [`document.baseURI`](/en-US/docs/Web/API/Document/baseURI).
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Usage notes
 
 If multiple `<base>` elements are specified, only the first `href` and
 first `target` value are used; all others are ignored.
-<!-- </usage-notes> -->
 
-<!-- <see-also> -->
-<!-- </see-also> -->
+## See also

--- a/content/html/elements/base/prose.md
+++ b/content/html/elements/base/prose.md
@@ -13,5 +13,3 @@ The base URL of a document can be queried from a script using
 
 If multiple `<base>` elements are specified, only the first `href` and
 first `target` value are used; all others are ignored.
-
-## See also

--- a/content/html/elements/bdi/prose.md
+++ b/content/html/elements/bdi/prose.md
@@ -1,12 +1,13 @@
-<!-- <short-description> -->
+## Short description
+
 The HTML **Bidirectional Isolate element** (**`<bdi>`**) tells the
 browser's bidirectional algorithm to treat the text it contains in
 isolation from its surrounding text. It's particularly
 useful when a website dynamically inserts some text and doesn't know
 the directionality of the text being inserted.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
+
 Bidirectional text is text that may contain both sequences of characters
 that are arranged left-to-right (LTR) and sequences of characters that
 are arranged right-to-left (RTL), such as an Arabic quotation embedded
@@ -26,10 +27,10 @@ The `<bdi>` element is used to wrap a span of text and instructs the
 bidirectional algorithm to treat this text in isolation from its
 surroundings. This works in two ways:
 
--   The directionality of text embedded in `<bdi>` *does not influence*
-    the directionality of the surrounding text.
--   The directionality of text embedded in `<bdi>` *is not influenced
-    by* the directionality of the surrounding text.
+- The directionality of text embedded in `<bdi>` *does not influence*
+  the directionality of the surrounding text.
+- The directionality of text embedded in `<bdi>` *is not influenced
+  by* the directionality of the surrounding text.
 
 For example, consider some text like:
 
@@ -64,30 +65,20 @@ CSS styling.
 
 Embedding the characters in `<span dir="auto">` has the same effect as
 using `<bdi>`, but its semantics are less clear.
-<!-- </overview> -->
 
-<!-- <attributes-text> -->
+## Attributes text
+
 The `dir` attribute behaves differently than normal: it defaults to `auto`,
 meaning its value is never inherited from the parent element. This means
 that unless you specify a value of either `"rtl"` or `"ltr"` for `dir`,
 the [user agent](/en-US/docs/Glossary/user_agent)
 will determine the correct directionality to use based on the contents
 of the `<bdi>`.
-<!-- </attributes-text> -->
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   [Inline markup and bidirectional text in
-    HTML](https://www.w3.org/International/articles/inline-bidi-markup/)
--   [Unicode Bidirectional Algorithm
-    basics](https://www.w3.org/International/articles/inline-bidi-markup/uba-basics)
--   [Localization and
-    Internationalization](/en-US/docs/Web/Localization)
--   Related HTML element:
-    [`<bdo>`](/en-US/docs/Web/HTML/Element/bdo)
--   Related CSS properties:
-    [`direction`](/en-US/docs/Web/CSS/direction),
-    [`unicode-bidi`](/en-US/docs/Web/CSS/unicode-bidi)
-<!-- </see-also> -->
+- [Inline markup and bidirectional text in HTML](https://www.w3.org/International/articles/inline-bidi-markup/)
+- [Unicode Bidirectional Algorithm basics](https://www.w3.org/International/articles/inline-bidi-markup/uba-basics)
+- [Localization and Internationalization](/en-US/docs/Web/Localization)
+- Related HTML element: [`<bdo>`](/en-US/docs/Web/HTML/Element/bdo)
+- Related CSS properties: [`direction`](/en-US/docs/Web/CSS/direction), [`unicode-bidi`](/en-US/docs/Web/CSS/unicode-bidi)

--- a/content/html/elements/bdo/prose.md
+++ b/content/html/elements/bdo/prose.md
@@ -1,10 +1,11 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML Bidirectional Text Override element** (**`<bdo>`**)
 overrides the current directionality of text, so that the text within is
 rendered in a different direction.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
+
 Bidirectional text is text that may contain both sequences of characters
 that are arranged left-to-right (LTR) and sequences of characters that
 are arranged right-to-left (RTL), such as an Arabic quotation embedded
@@ -24,10 +25,10 @@ The `<bdi>` element is used to wrap a span of text and instructs the
 bidirectional algorithm to treat this text in isolation from its
 surroundings. This works in two ways:
 
--   The directionality of text embedded in `<bdi>` *does not influence*
-    the directionality of the surrounding text.
--   The directionality of text embedded in `<bdi>` *is not influenced
-    by* the directionality of the surrounding text.
+- The directionality of text embedded in `<bdi>` *does not influence*
+  the directionality of the surrounding text.
+- The directionality of text embedded in `<bdi>` *is not influenced
+  by* the directionality of the surrounding text.
 
 For example, consider some text like:
 
@@ -62,20 +63,11 @@ CSS styling.
 
 Embedding the characters in `<span dir="auto">` has the same effect as
 using `<bdi>`, but its semantics are less clear.
-<!-- </overview> -->
 
-<!-- <attributes-text> -->
+## Attributes text
 When used with `<bdo>` the [`dir`](/en-US/docs/Web/HTML/Global_attributes/dir) attribute is mandatory and describes the direction in which text should be rendered inside the element's Possible values are:
--   `ltr`: Indicates that the text should go in a left-to-right
-        direction.
--   `rtl`: Indicates that the text should go in a right-to-left
-        direction.
-<!-- </attributes-text> -->
+- `ltr`: Indicates that the text should go in a left-to-right direction.
+- `rtl`: Indicates that the text should go in a right-to-left direction.
 
-<!-- <see-also> -->
-See also
---------
-
--   [Inline markup and bidirectional text in
-    HTML](https://www.w3.org/International/articles/inline-bidi-markup/)
-<!-- </see-also> -->
+## See also
+- [Inline markup and bidirectional text in HTML](https://www.w3.org/International/articles/inline-bidi-markup/)

--- a/content/html/elements/blockquote/prose.md
+++ b/content/html/elements/blockquote/prose.md
@@ -9,8 +9,6 @@ given using the
 [`<cite>`](/en-US/docs/Web/HTML/Element/cite)
 element.
 
-## Overview
-
 ## Usage notes
 
 To change the indentation applied to the quoted text, use the

--- a/content/html/elements/blockquote/prose.md
+++ b/content/html/elements/blockquote/prose.md
@@ -1,4 +1,5 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<blockquote>` Element** (or *HTML Block Quotation Element*)
 indicates that the enclosed text is an extended quotation. Usually, this
 is rendered visually by indentation (see [Usage notes](#Usage_notes) for how
@@ -7,15 +8,10 @@ the **cite** attribute, while a text representation of the source can be
 given using the
 [`<cite>`](/en-US/docs/Web/HTML/Element/cite)
 element.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
-
-Usage notes
------------
+## Usage notes
 
 To change the indentation applied to the quoted text, use the
 [CSS](/en-US/docs/Glossary/CSS")
@@ -30,17 +26,10 @@ To include shorter quotes inline rather than in a separate block, use
 the
 [`<q>`](/en-US/docs/Web/HTML/Element/q)
 (Quotation) element.
-<!-- </usage-notes> -->
 
-<!-- <see-also> -->
+## See also
 
-See also
---------
-
--   The
-    [`<q>`](/en-US/docs/Web/HTML/Element/q)
-    element for inline quotations.
--   The
-    [`<cite>`](/en-US/docs/Web/HTML/Element/cite)
-    element for source citations.
-<!-- </see-also> -->
+- The [`<q>`](/en-US/docs/Web/HTML/Element/q)
+  element for inline quotations.
+- The [`<cite>`](/en-US/docs/Web/HTML/Element/cite)
+  element for source citations.

--- a/content/html/elements/body/prose.md
+++ b/content/html/elements/body/prose.md
@@ -3,10 +3,6 @@
 The **HTML `<body>` Element** represents the content of an HTML
 document. There can be only one `<body>` element in a document.
 
-## Overview
-
-## Usage notes
-
 ## See also
 
 - [`<html>`](/en-US/docs/Web/HTML/Element/html)

--- a/content/html/elements/body/prose.md
+++ b/content/html/elements/body/prose.md
@@ -1,19 +1,13 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<body>` Element** represents the content of an HTML
 document. There can be only one `<body>` element in a document.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
-<!-- </usage-notes> -->
+## Usage notes
 
-<!-- <see-also> -->
+## See also
 
-See also
---------
-
--   [`<html>`](/en-US/docs/Web/HTML/Element/html)
--   [`<head>`](/en-US/docs/Web/HTML/Element/head)
-<!-- </see-also> -->
+- [`<html>`](/en-US/docs/Web/HTML/Element/html)
+- [`<head>`](/en-US/docs/Web/HTML/Element/head)

--- a/content/html/elements/br/prose.md
+++ b/content/html/elements/br/prose.md
@@ -1,10 +1,11 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<br>` element** produces a line break in text
 (carriage-return). It is useful for writing a poem or an address, where
 the division of lines is significant.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
+
 A `<br>` element is included at each point where we want the text to break. The text after the `<br>`
 begins again at the start of the next line of the text block.
 
@@ -14,17 +15,13 @@ them in
 elements and use the [CSS](/en-US/docs/CSS)
 [`margin`](/en-US/docs/Web/CSS/margin)
 property to control their size.
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Usage notes
 
 If multiple `<base>` elements are specified, only the first `href` and
 first `target` value are used; all others are ignored.
-<!-- </usage-notes> -->
 
-<!-- <accessibility-concerns> -->
+## Accessibility concerns
 Creating separate paragraphs of text using `<br>` is not only bad
 practice, it is problematic for people who navigate with the aid of
 screen reading technology. Screen readers may announce the presence of
@@ -35,11 +32,9 @@ reader.
 Use `<p>` elements, and use CSS properties like
 [`margin`](/en-US/docs/Web/CSS/margin)
 to control their spacing.
-<!-- </accessibility-concerns> -->
 
-<!-- <styling-with-css> -->
-Styling with CSS
-----------------
+
+## Styling with CSS
 
 The `<br>` element has a single, well-defined purpose - to create a
 line break in a block of text. As such, it has no dimensions or visual
@@ -51,16 +46,8 @@ on `<br>` elements themselves to increase the spacing between the lines
 of text in the block, but this is a bad practice - you should use the
 [`line-height`](/en-US/docs/Web/CSS/line-height)
 property that was designed for that purpose.
-<!-- </styling-with-css> -->
 
-<!-- <see-also> -->
+## See also
 
-
-See also
---------
-
--   [`<address>`](/en-US/docs/Web/HTML/Element/address)
-    element
--   [`<p>`](/en-US/docs/Web/HTML/Element/p)
-    element
-<!-- </see-also> -->
+- [`<address>`](/en-US/docs/Web/HTML/Element/address) element
+- [`<p>`](/en-US/docs/Web/HTML/Element/p) element

--- a/content/html/elements/button/attributes/formtarget.md
+++ b/content/html/elements/button/attributes/formtarget.md
@@ -13,17 +13,17 @@ the button's form owner.
 
 The following keywords have special
 meanings:
--   `_self`: Load the response into the same browsing context as the
-    current one. This value is the default if the attribute is not
-    specified.
--   `_blank`: Load the response into a new unnamed browsing context.
--   `_parent`: Load the response into the parent browsing context of
-    the current one. If there is no parent, this option behaves the
-    same way as `_self`.
--   `_top`: Load the response into the top-level browsing context
-    (that is, the browsing context that is an ancestor of the
-    current one, and has no parent). If there is no parent, this
-    option behaves the same way as `_self`.
+- `_self`: Load the response into the same browsing context as the
+  current one. This value is the default if the attribute is not
+  specified.
+- `_blank`: Load the response into a new unnamed browsing context.
+- `_parent`: Load the response into the parent browsing context of
+  the current one. If there is no parent, this option behaves the
+  same way as `_self`.
+- `_top`: Load the response into the top-level browsing context
+  (that is, the browsing context that is an ancestor of the
+  current one, and has no parent). If there is no parent, this
+  option behaves the same way as `_self`.
 
 ## Type
 

--- a/content/html/elements/button/prose.md
+++ b/content/html/elements/button/prose.md
@@ -1,19 +1,17 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<button>` element** represents a clickable button, which
 can be used in [forms](/en-US/docs/Learn/HTML/Forms) or anywhere in a
 document that needs simple, standard button functionality.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
+
 By default, HTML buttons are typically presented in a style similar to
 that of the host platform the [user agent](/en-US/docs/Glossary/user_agent)
 is running on, but you can change the appearance of the button using
 [CSS](/en-US/docs/Web/CSS).
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Usage notes
 
 `<button>` elements are much easier to style than
 [`<input>`](/en-US/docs/Web/HTML/Element/input)
@@ -46,9 +44,7 @@ gradient on all buttons (see [bug
 763671](https://bugzilla.mozilla.org/show_bug.cgi?id=763671)).
 This can be disabled using `background-image: none`.
 
-<!-- </usage-notes> -->
-
-<!-- <accessibility-concerns> -->
+## Accessibility concerns
 ### Icon buttons
 
 Buttons that only use an icon to represent functionality do not have an
@@ -84,10 +80,9 @@ or understand the button's purpose. This is especially relevant for
 people who are not as technologically sophisticated, or who may have
 different cultural interpretations for the imagery the icon button uses.
 
--   [What is an accessible name? | The Paciello
-    Group](https://developer.paciellogroup.com/blog/2017/04/what-is-an-accessible-name/)
--   [MDN Understanding WCAG, Guideline 4.1 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Robust#Guideline_4.1_—_Compatible_Maximize_compatibility_with_current_and_future_user_agents_including_assistive_technologies)
--   [Understanding Success Criterion 4.1.2 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/ensure-compat-rsv.html)
+- [What is an accessible name? | The Paciello Group](https://developer.paciellogroup.com/blog/2017/04/what-is-an-accessible-name/)
+- [MDN Understanding WCAG, Guideline 4.1 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Robust#Guideline_4.1_—_Compatible_Maximize_compatibility_with_current_and_future_user_agents_including_assistive_technologies)
+- [Understanding Success Criterion 4.1.2 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/ensure-compat-rsv.html)
 
 ### Proximity
 
@@ -100,8 +95,7 @@ wrong interactive content.
 Spacing may be created using CSS properties such as
 [`margin`](/en-US/docs/Web/CSS/margin "The margin CSS property sets the margin area on all four sides of an element. It is a shorthand for margin-top, margin-right, margin-bottom, and margin-left.").
 
--   [Hand tremors and the giant-button-problem - Axess
-    Lab](https://axesslab.com/hand-tremors/)
+- [Hand tremors and the giant-button-problem - Axess Lab](https://axesslab.com/hand-tremors/)
 
 ### Firefox
 
@@ -123,10 +117,9 @@ Large text is defined as `18.66px` and
 [`bold`](/en-US/docs/Web/CSS/font-weight "The documentation about this has not yet been written; please consider contributing!")
 or larger, or `24px` or larger.
 
--   [WebAIM: Color Contrast
-    Checker](https://webaim.org/resources/contrastchecker/)
--   [MDN Understanding WCAG, Guideline 1.4 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#Guideline_1.4_Make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background)
--   [Understanding Success Criterion 1.4.3 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)
+- [WebAIM: Color Contrast Checker](https://webaim.org/resources/contrastchecker/)
+- [MDN Understanding WCAG, Guideline 1.4 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#Guideline_1.4_Make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background)
+- [Understanding Success Criterion 1.4.3 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)
 
 ### Clicking and focus
 
@@ -137,7 +130,7 @@ results for
 [`<input>`](/en-US/docs/Web/HTML/Element/input)
 of `type="button"` and `type="submit"` were the same.
 
-** Does clicking on a
+**Does clicking on a
   [`<button>`](/en-US/docs/Web/HTML/Element/button)
   give it the focus?**
 
@@ -145,17 +138,13 @@ of `type="button"` and `type="submit"` were the same.
 
 * On macOS, clicking a button gives it the focus on Chrome, but not on Firefox or Safari.
 
-** Does tapping on [`<button>`](/en-US/docs/Web/HTML/Element/button) give it the focus?**
+**Does tapping on [`<button>`](/en-US/docs/Web/HTML/Element/button) give it the focus?**
 
 * On iOS, tapping a button does not give it focus on Chrome or Safari.
 
 * On Android, tapping a button does give it focus on Chrome.
 
-<!-- </accessibility-concerns> -->
-<!-- <see-also> -->
-
-See also
---------
+## See also
 
 Other elements that are used for creating forms:
 [`<form>`](/en-US/docs/Web/HTML/Element/form),
@@ -171,4 +160,3 @@ Other elements that are used for creating forms:
 [`<progress>`](/en-US/docs/Web/HTML/Element/progress),
 [`<select>`](/en-US/docs/Web/HTML/Element/select),
 [`<textarea>`](/en-US/docs/Web/HTML/Element/textarea).
-<!-- </see-also> -->

--- a/content/html/elements/canvas/prose.md
+++ b/content/html/elements/canvas/prose.md
@@ -4,8 +4,6 @@ Use the **HTML `<canvas>` element** with either the [canvas scripting
 API](/en-US/docs/Web/API/Canvas_API) or the [WebGL
 API](/en-US/docs/Web/API/WebGL_API) to draw graphics and animations.
 
-## Overview
-
 ## Usage notes
 
 ### Alternative content

--- a/content/html/elements/canvas/prose.md
+++ b/content/html/elements/canvas/prose.md
@@ -1,16 +1,12 @@
-<!-- <short-description> -->
+## Short description
+
 Use the **HTML `<canvas>` element** with either the [canvas scripting
 API](/en-US/docs/Web/API/Canvas_API) or the [WebGL
 API](/en-US/docs/Web/API/WebGL_API) to draw graphics and animations.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
-
-Usage notes
------------
+## Usage notes
 
 ### Alternative content
 
@@ -44,28 +40,26 @@ from various tests and other sources (e.g. [Stack
 Overflow](https://stackoverflow.com/questions/6081483/maximum-size-of-a-canvas-element)):
 
 * Chrome
-    * Maximum height: 32,767 pixels
-    * Maximum width: 32,767 pixels
-    * Maximum area: 268,435,456 pixels (i.e., 16,384 x 16,384)
+  * Maximum height: 32,767 pixels
+  * Maximum width: 32,767 pixels
+  * Maximum area: 268,435,456 pixels (i.e., 16,384 x 16,384)
 * Firefox
-    * Maximum height: 32,767 pixels
-    * Maximum width: 32,767 pixels
-    * Maximum area: 472,907,776 pixels (i.e., 22,528 x 20,992)
+  * Maximum height: 32,767 pixels
+  * Maximum width: 32,767 pixels
+  * Maximum area: 472,907,776 pixels (i.e., 22,528 x 20,992)
 * Safari
-    * Maximum height: 32,767 pixels
-    * Maximum width: 32,767 pixels
-    * Maximum area: 268,435,456 pixels (i.e., 16,384 x 16,384)
+  * Maximum height: 32,767 pixels
+  * Maximum width: 32,767 pixels
+  * Maximum area: 268,435,456 pixels (i.e., 16,384 x 16,384)
 * IE
-    * Maximum height: 8,192 pixels
-    * Maximum width: 8,192 pixels
-    * Maximum area: ?
+  * Maximum height: 8,192 pixels
+  * Maximum width: 8,192 pixels
+  * Maximum area: ?
 
 **Note**: Exceeding the maximum dimensions or area renders the canvas
 unusable --- drawing commands will not work.
 
-<!-- </usage-notes> -->
-
-<!-- <accessibility-concerns> -->
+## Accessibility concerns
 ### Alternative content
 
 The
@@ -76,26 +70,15 @@ tools like semantic HTML is. In general, you should avoid using canvas
 in an accessible website or app. The following guides can help to make
 it more accessible.
 
--   [MDN Hit regions and
-    accessibility](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility)
--   [Canvas accessibility use
-    cases](https://www.w3.org/WAI/PF/HTML/wiki/Canvas_Accessibility_Use_Cases)
--   [Canvas element accessibility
-    issues](https://www.w3.org/html/wg/wiki/AddedElementCanvas)
--   [HTML5 Canvas Accessibility in Firefox 13 -- by Steve
-    Faulkner](http://www.paciellogroup.com/blog/2012/06/html5-canvas-accessibility-in-firefox-13/)
--   [Best practices for interactive canvas
-    elements](https://html.spec.whatwg.org/multipage/scripting.html#best-practices)
+- [MDN Hit regions and accessibility](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility)
+- [Canvas accessibility use cases](https://www.w3.org/WAI/PF/HTML/wiki/Canvas_Accessibility_Use_Cases)
+- [Canvas element accessibility issues](https://www.w3.org/html/wg/wiki/AddedElementCanvas)
+- [HTML5 Canvas Accessibility in Firefox 13 -- by Steve Faulkner](http://www.paciellogroup.com/blog/2012/06/html5-canvas-accessibility-in-firefox-13/)
+- [Best practices for interactive canvas elements](https://html.spec.whatwg.org/multipage/scripting.html#best-practices)
 
-<!-- </accessibility-concerns> -->
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   [MDN canvas portal](/en-US/docs/Web/API/Canvas_API)
--   [Canvas tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial)
--   [Canvas cheat
-    sheet](https://simon.html5.org/dump/html5-canvas-cheat-sheet.html)
--   [Canvas introduction by
-    Apple](https://developer.apple.com/library/safari/documentation/AudioVideo/Conceptual/HTML-canvas-guide/Introduction/Introduction.html)
-<!-- </see-also> -->
+- [MDN canvas portal](/en-US/docs/Web/API/Canvas_API)
+- [Canvas tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial)
+- [Canvas cheat sheet](https://simon.html5.org/dump/html5-canvas-cheat-sheet.html)
+- [Canvas introduction by Apple](https://developer.apple.com/library/safari/documentation/AudioVideo/Conceptual/HTML-canvas-guide/Introduction/Introduction.html)

--- a/content/html/elements/caption/prose.md
+++ b/content/html/elements/caption/prose.md
@@ -4,8 +4,6 @@ The **HTML Table Caption element** (**`<caption>`**) specifies the
 caption (or title) of a table, and if used is *always* the first child
 of a [`<table>`](/en-US/docs/Web/HTML/Element/table).
 
-## Overview
-
 ## Usage notes
 
 When the
@@ -23,8 +21,8 @@ and
 [`text-align`](/en-US/docs/Web/CSS/text-align)
 properties.
 
-
 ## See also
+
 - Other table-related HTML Elements:
   [`<col>`](/en-US/docs/Web/HTML/Element/col),
   [`<colgroup>`](/en-US/docs/Web/HTML/Element/colgroup),

--- a/content/html/elements/caption/prose.md
+++ b/content/html/elements/caption/prose.md
@@ -1,15 +1,12 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML Table Caption element** (**`<caption>`**) specifies the
 caption (or title) of a table, and if used is *always* the first child
 of a [`<table>`](/en-US/docs/Web/HTML/Element/table).
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Usage notes
 
 When the
 [`<table>`](/en-US/docs/Web/HTML/Element/table)
@@ -25,22 +22,19 @@ using the CSS
 and
 [`text-align`](/en-US/docs/Web/CSS/text-align)
 properties.
-<!-- </usage-notes> -->
 
-<!-- <see-also> -->
-See also
---------
--   Other table-related HTML Elements:
-    [`<col>`](/en-US/docs/Web/HTML/Element/col),
-    [`<colgroup>`](/en-US/docs/Web/HTML/Element/colgroup),
-    [`<table>`](/en-US/docs/Web/HTML/Element/table),
-    [`<tbody>`](/en-US/docs/Web/HTML/Element/tbody),
-    [`<td>`](/en-US/docs/Web/HTML/Element/td),
-    [`<tfoot>`](/en-US/docs/Web/HTML/Element/tfoot),
-    [`<th>`](/en-US/docs/Web/HTML/Element/th),
-    [`<thead>`](/en-US/docs/Web/HTML/Element/thead),
-    [`<tr>`](/en-US/docs/Web/HTML/Element/tr);
--   CSS properties that may be specially useful to style the
-    [`<caption>`](/en-US/docs/Web/HTML/Element/caption)
-    element: [`text-align`](/en-US/docs/Web/CSS/text-align), [`caption-side`](/en-US/docs/Web/CSS/caption-side).
-<!-- </see-also> -->
+
+## See also
+- Other table-related HTML Elements:
+  [`<col>`](/en-US/docs/Web/HTML/Element/col),
+  [`<colgroup>`](/en-US/docs/Web/HTML/Element/colgroup),
+  [`<table>`](/en-US/docs/Web/HTML/Element/table),
+  [`<tbody>`](/en-US/docs/Web/HTML/Element/tbody),
+  [`<td>`](/en-US/docs/Web/HTML/Element/td),
+  [`<tfoot>`](/en-US/docs/Web/HTML/Element/tfoot),
+  [`<th>`](/en-US/docs/Web/HTML/Element/th),
+  [`<thead>`](/en-US/docs/Web/HTML/Element/thead),
+  [`<tr>`](/en-US/docs/Web/HTML/Element/tr);
+- CSS properties that may be specially useful to style the
+  [`<caption>`](/en-US/docs/Web/HTML/Element/caption)
+  element: [`text-align`](/en-US/docs/Web/CSS/text-align), [`caption-side`](/en-US/docs/Web/CSS/caption-side).

--- a/content/html/elements/cite/prose.md
+++ b/content/html/elements/cite/prose.md
@@ -1,49 +1,44 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML Citation element** (**`<cite>`**) is used to describe a
 reference to a cited creative work, and must include either the title or
 author or the URL of that work. The reference may be in an
 abbreviated form according to context-appropriate conventions related to
 citation metadata.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
-
-
-Usage notes
------------
+## Usage notes
 
 In the context of the `<cite>` element, a creative work that might be
 cited could be, for example, one of the following:
 
--   A book
--   A research paper
--   An essay
--   A poem
--   A musical score
--   A song
--   A play or film script
--   A film
--   A television show
--   A game
--   A sculpture
--   A painting
--   A theatrical production
--   A play
--   An opera
--   A musical
--   An exhibition
--   A legal case report
--   A computer program
--   A web site
--   A web page
--   A blog post or comment
--   A forum post or comment
--   A tweet
--   A Facebook post
--   A written or oral statement
+- A book
+- A research paper
+- An essay
+- A poem
+- A musical score
+- A song
+- A play or film script
+- A film
+- A television show
+- A game
+- A sculpture
+- A painting
+- A theatrical production
+- A play
+- An opera
+- A musical
+- An exhibition
+- A legal case report
+- A computer program
+- A web site
+- A web page
+- A blog post or comment
+- A forum post or comment
+- A tweet
+- A Facebook post
+- A written or oral statement
 
 The W3C specification says that a reference to a
 creative work, as included within a `<cite>` element, may include the
@@ -62,17 +57,13 @@ Typically, browsers style the contents of a `<cite>` element in italics
 by default. To avoid this, apply the CSS
 [`font-style`](/en-US/docs/Web/CSS/font-style)
 property to the `<cite>` element.
-<!-- </usage-notes> -->
 
-<!-- <see-also> -->
 
-See also
---------
+## See also
 
--   The element
-    [`<blockquote>`](/en-US/docs/Web/HTML/Element/blockquote)
-    for long quotations.
--   The element
-    [`<q>`](/en-US/docs/Web/HTML/Element/q)
-    for inline quotations.
-<!-- </see-also> -->
+- The element
+  [`<blockquote>`](/en-US/docs/Web/HTML/Element/blockquote)
+  for long quotations.
+- The element
+  [`<q>`](/en-US/docs/Web/HTML/Element/q)
+  for inline quotations.

--- a/content/html/elements/cite/prose.md
+++ b/content/html/elements/cite/prose.md
@@ -6,8 +6,6 @@ author or the URL of that work. The reference may be in an
 abbreviated form according to context-appropriate conventions related to
 citation metadata.
 
-## Overview
-
 ## Usage notes
 
 In the context of the `<cite>` element, a creative work that might be
@@ -57,7 +55,6 @@ Typically, browsers style the contents of a `<cite>` element in italics
 by default. To avoid this, apply the CSS
 [`font-style`](/en-US/docs/Web/CSS/font-style)
 property to the `<cite>` element.
-
 
 ## See also
 

--- a/content/html/elements/code/prose.md
+++ b/content/html/elements/code/prose.md
@@ -1,16 +1,14 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<code>` element** displays its contents styled in a fashion
 intended to indicate that the text is a short fragment of computer
 code. By default, the content text is displayed using the
 [user agent's](/en-US/docs/Glossary/user_agent) default monospace font.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Usage notes
+
 To represent multiple lines of code, wrap the `<code>` element within a
 [`<pre>`](/en-US/docs/Web/HTML/Element/pre)
 element. The `<code>` element by itself only represents a single phrase
@@ -19,16 +17,12 @@ of code or line of code.
 A CSS rule can be defined for the `code` selector to override the
 browser's default font face. Preferences set by the user might take
 precedence over the specified CSS.
-<!-- </usage-notes> -->
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   [`<samp>`](/en-US/docs/Web/HTML/Element/samp)
--   [`<kbd>`](/en-US/docs/Web/HTML/Element/kbd)
--   [`<command>`](/en-US/docs/Web/HTML/Element/command)
-    (deprecated)
--   [`<var>`](/en-US/docs/Web/HTML/Element/var)
--   [`<pre>`](/en-US/docs/Web/HTML/Element/pre)
-<!-- </see-also> -->
+- [`<samp>`](/en-US/docs/Web/HTML/Element/samp)
+- [`<kbd>`](/en-US/docs/Web/HTML/Element/kbd)
+- [`<command>`](/en-US/docs/Web/HTML/Element/command)
+  (deprecated)
+- [`<var>`](/en-US/docs/Web/HTML/Element/var)
+- [`<pre>`](/en-US/docs/Web/HTML/Element/pre)

--- a/content/html/elements/code/prose.md
+++ b/content/html/elements/code/prose.md
@@ -5,8 +5,6 @@ intended to indicate that the text is a short fragment of computer
 code. By default, the content text is displayed using the
 [user agent's](/en-US/docs/Glossary/user_agent) default monospace font.
 
-## Overview
-
 ## Usage notes
 
 To represent multiple lines of code, wrap the `<code>` element within a

--- a/content/html/elements/col/prose.md
+++ b/content/html/elements/col/prose.md
@@ -1,43 +1,38 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<col>` element** defines a column within a table and is used
 for defining common semantics on all common cells. It is generally found
 within a [`<colgroup>`](/en-US/docs/Web/HTML/Element/colgroup) element.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
+
 This element allows styling columns using CSS, but only a few properties
 will have an effect on the column ([see the CSS 2.1
 specification](https://www.w3.org/TR/CSS21/tables.html#columns) for a
 list).
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-<!-- </usage-notes> -->
+## Usage notes
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   Other table-related HTML elements:
-    [`<caption>`](/en-US/docs/Web/HTML/Element/caption),
-    [`<colgroup>`](/en-US/docs/Web/HTML/Element/colgroup),
-    [`<table>`](/en-US/docs/Web/HTML/Element/table),
-    [`<tbody>`](/en-US/docs/Web/HTML/Element/tbody),
-    [`<td>`](/en-US/docs/Web/HTML/Element/td),
-    [`<tfoot>`](/en-US/docs/Web/HTML/Element/tfoot),
-    [`<th>`](/en-US/docs/Web/HTML/Element/th),
-    [`<thead>`](/en-US/docs/Web/HTML/Element/thead),
-    [`<tr>`](/en-US/docs/Web/HTML/Element/tr);
--   CSS properties and pseudo-classes that may be specially useful to
-    style the `<col>` element:
-    -   the
-        [`width`](/en-US/docs/Web/CSS/width)
-        property to control the width of the column;
-    -   the
-        [`:nth-child`](/en-US/docs/Web/CSS/:nth-child)
-        pseudo-class to set the alignment on the cells of the column;
-    -   the
-        [`text-align`](/en-US/docs/Web/CSS/text-align)
-        property to align all cells content on the same character
-
-<!-- </see-also> -->
+- Other table-related HTML elements:
+  [`<caption>`](/en-US/docs/Web/HTML/Element/caption),
+  [`<colgroup>`](/en-US/docs/Web/HTML/Element/colgroup),
+  [`<table>`](/en-US/docs/Web/HTML/Element/table),
+  [`<tbody>`](/en-US/docs/Web/HTML/Element/tbody),
+  [`<td>`](/en-US/docs/Web/HTML/Element/td),
+  [`<tfoot>`](/en-US/docs/Web/HTML/Element/tfoot),
+  [`<th>`](/en-US/docs/Web/HTML/Element/th),
+  [`<thead>`](/en-US/docs/Web/HTML/Element/thead),
+  [`<tr>`](/en-US/docs/Web/HTML/Element/tr);
+- CSS properties and pseudo-classes that may be specially useful to
+  style the `<col>` element:
+  - the
+    [`width`](/en-US/docs/Web/CSS/width)
+    property to control the width of the column;
+  - the
+    [`:nth-child`](/en-US/docs/Web/CSS/:nth-child)
+    pseudo-class to set the alignment on the cells of the column;
+  - the
+    [`text-align`](/en-US/docs/Web/CSS/text-align)
+    property to align all cells content on the same character

--- a/content/html/elements/col/prose.md
+++ b/content/html/elements/col/prose.md
@@ -11,8 +11,6 @@ will have an effect on the column ([see the CSS 2.1
 specification](https://www.w3.org/TR/CSS21/tables.html#columns) for a
 list).
 
-## Usage notes
-
 ## See also
 
 - Other table-related HTML elements:

--- a/content/html/elements/colgroup/prose.md
+++ b/content/html/elements/colgroup/prose.md
@@ -1,41 +1,36 @@
-<!-- <short-description> -->
-The **HTML `<colgroup>` element** defines a group of columns within a table.
-<!-- </short-description> -->
+## Short description
 
-<!-- <overview> -->
+The **HTML `<colgroup>` element** defines a group of columns within a table.
+
+## Overview
+
 This element allows styling columns using CSS, but only a few properties
 will have an effect on the column ([see the CSS 2.1
 specification](https://www.w3.org/TR/CSS21/tables.html#columns) for a
 list).
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-<!-- </usage-notes> -->
+## Usage notes
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   Other table-related HTML elements:
-    [`<caption>`](/en-US/docs/Web/HTML/Element/caption),
-    [`<colgroup>`](/en-US/docs/Web/HTML/Element/colgroup),
-    [`<table>`](/en-US/docs/Web/HTML/Element/table),
-    [`<tbody>`](/en-US/docs/Web/HTML/Element/tbody),
-    [`<td>`](/en-US/docs/Web/HTML/Element/td),
-    [`<tfoot>`](/en-US/docs/Web/HTML/Element/tfoot),
-    [`<th>`](/en-US/docs/Web/HTML/Element/th),
-    [`<thead>`](/en-US/docs/Web/HTML/Element/thead),
-    [`<tr>`](/en-US/docs/Web/HTML/Element/tr);
--   CSS properties and pseudo-classes that may be specially useful to
-    style the `<col>` element:
-    -   the
-        [`width`](/en-US/docs/Web/CSS/width)
-        property to control the width of the column;
-    -   the
-        [`:nth-child`](/en-US/docs/Web/CSS/:nth-child)
-        pseudo-class to set the alignment on the cells of the column;
-    -   the
-        [`text-align`](/en-US/docs/Web/CSS/text-align)
-        property to align all cells content on the same character
-
-<!-- </see-also> -->
+- Other table-related HTML elements:
+  [`<caption>`](/en-US/docs/Web/HTML/Element/caption),
+  [`<colgroup>`](/en-US/docs/Web/HTML/Element/colgroup),
+  [`<table>`](/en-US/docs/Web/HTML/Element/table),
+  [`<tbody>`](/en-US/docs/Web/HTML/Element/tbody),
+  [`<td>`](/en-US/docs/Web/HTML/Element/td),
+  [`<tfoot>`](/en-US/docs/Web/HTML/Element/tfoot),
+  [`<th>`](/en-US/docs/Web/HTML/Element/th),
+  [`<thead>`](/en-US/docs/Web/HTML/Element/thead),
+  [`<tr>`](/en-US/docs/Web/HTML/Element/tr);
+- CSS properties and pseudo-classes that may be specially useful to
+  style the `<col>` element:
+  - the
+    [`width`](/en-US/docs/Web/CSS/width)
+    property to control the width of the column;
+  - the
+    [`:nth-child`](/en-US/docs/Web/CSS/:nth-child)
+    pseudo-class to set the alignment on the cells of the column;
+  - the
+    [`text-align`](/en-US/docs/Web/CSS/text-align)
+    property to align all cells content on the same character

--- a/content/html/elements/colgroup/prose.md
+++ b/content/html/elements/colgroup/prose.md
@@ -9,8 +9,6 @@ will have an effect on the column ([see the CSS 2.1
 specification](https://www.w3.org/TR/CSS21/tables.html#columns) for a
 list).
 
-## Usage notes
-
 ## See also
 
 - Other table-related HTML elements:

--- a/content/html/elements/data/prose.md
+++ b/content/html/elements/data/prose.md
@@ -5,10 +5,6 @@ machine-readable translation. If the content is time- or date-related,
 the [`<time>`](/en-US/docs/Web/HTML/Element/time)
 element must be used.
 
-## Overview
-
-## Usage notes
-
 ## See also
 
 - The HTML [`<time>`](/en-US/docs/Web/HTML/Element/time) element.

--- a/content/html/elements/data/prose.md
+++ b/content/html/elements/data/prose.md
@@ -1,19 +1,14 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<data>` element** links a given content with a
 machine-readable translation. If the content is time- or date-related,
 the [`<time>`](/en-US/docs/Web/HTML/Element/time)
 element must be used.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
-<!-- </usage-notes> -->
+## Usage notes
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   The HTML [`<time>`](/en-US/docs/Web/HTML/Element/time) element.
-<!-- </see-also> -->
+- The HTML [`<time>`](/en-US/docs/Web/HTML/Element/time) element.

--- a/content/html/elements/datalist/prose.md
+++ b/content/html/elements/datalist/prose.md
@@ -1,21 +1,16 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<datalist>` element** contains a set of
 [`<option>`](/en-US/docs/Web/HTML/Element/option)
 elements that represent the values available for other controls.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
-<!-- </usage-notes> -->
+## Usage notes
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   The [`<input>`](/en-US/docs/Web/HTML/Element/input)
-    element, and more specifically its `list` attribute;
--   The [`<option>`](/en-US/docs/Web/HTML/Element/option)
-    element.
-<!-- </see-also> -->
+- The [`<input>`](/en-US/docs/Web/HTML/Element/input)
+  element, and more specifically its `list` attribute;
+- The [`<option>`](/en-US/docs/Web/HTML/Element/option)
+  element.

--- a/content/html/elements/datalist/prose.md
+++ b/content/html/elements/datalist/prose.md
@@ -4,10 +4,6 @@ The **HTML `<datalist>` element** contains a set of
 [`<option>`](/en-US/docs/Web/HTML/Element/option)
 elements that represent the values available for other controls.
 
-## Overview
-
-## Usage notes
-
 ## See also
 
 - The [`<input>`](/en-US/docs/Web/HTML/Element/input)

--- a/content/html/elements/dd/prose.md
+++ b/content/html/elements/dd/prose.md
@@ -6,10 +6,6 @@ definition of the preceding term
 in a description list
 ([`<dl>`](/en-US/docs/Web/HTML/Element/dl)).
 
-## Overview
-
-## Usage notes
-
 ## See also
 
 - [`<dl>`](/en-US/docs/Web/HTML/Element/dl)

--- a/content/html/elements/dd/prose.md
+++ b/content/html/elements/dd/prose.md
@@ -1,21 +1,16 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<dd>` element** provides the details about or the
 definition of the preceding term
 ([`<dt>`](/en-US/docs/Web/HTML/Element/dt))
 in a description list
 ([`<dl>`](/en-US/docs/Web/HTML/Element/dl)).
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
-<!-- </usage-notes> -->
+## Usage notes
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   [`<dl>`](/en-US/docs/Web/HTML/Element/dl)
--   [`<dt>`](/en-US/docs/Web/HTML/Element/dt)
-<!-- </see-also> -->
+- [`<dl>`](/en-US/docs/Web/HTML/Element/dl)
+- [`<dt>`](/en-US/docs/Web/HTML/Element/dt)

--- a/content/html/elements/del/prose.md
+++ b/content/html/elements/del/prose.md
@@ -1,19 +1,17 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<del>` element** represents a range of text that has been
 deleted from a document. This can be used when rendering
 change tracking or source code diffs, for example. The
 [`<ins>`](/en-US/docs/Web/HTML/Element/ins)
 element can be used for the opposite purpose: to indicate text that has
 been added to the document.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
-<!-- </usage-notes> -->
+## Usage notes
 
-<!-- <accessibility-concerns> -->
+## Accessibility concerns
 The presence of the `del` element is not announced by most screen
 reading technology in its default configuration. It can be made to be
 announced by using the CSS
@@ -25,7 +23,7 @@ and
 pseudo-elements.
 
 ```css
-    del::before, 
+    del::before,
     del::after {
       clip-path: inset(100%);
       clip: rect(1px, 1px, 1px, 1px);
@@ -50,19 +48,15 @@ content that creates extra verbosity. Because of this, it is important
 to not abuse this technique and only apply it in situations where not
 knowing content has been deleted would adversely affect understanding.
 
--   [Short note on making your mark (more accessible) \| The Paciello
-    Group](https://developer.paciellogroup.com/blog/2017/12/short-note-on-making-your-mark-more-accessible/)
--   [Tweaking Text Level Styles \| Adrian
-    Roselli](http://adrianroselli.com/2017/12/tweaking-text-level-styles.html)
-<!-- </accessibility-concerns> -->
+- [Short note on making your mark (more accessible) \| The Paciello
+  Group](https://developer.paciellogroup.com/blog/2017/12/short-note-on-making-your-mark-more-accessible/)
+- [Tweaking Text Level Styles \| Adrian
+  Roselli](http://adrianroselli.com/2017/12/tweaking-text-level-styles.html)
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   [`<ins>`](/en-US/docs/Web/HTML/Element/ins)
-    element for insertions into a text
--   [`<s>`](/en-US/docs/Web/HTML/Element/s)
-    element for strike-through separate from representing deletion of
-    text
-<!-- </see-also> -->
+- [`<ins>`](/en-US/docs/Web/HTML/Element/ins)
+  element for insertions into a text
+- [`<s>`](/en-US/docs/Web/HTML/Element/s)
+  element for strike-through separate from representing deletion of
+  text

--- a/content/html/elements/del/prose.md
+++ b/content/html/elements/del/prose.md
@@ -7,10 +7,6 @@ change tracking or source code diffs, for example. The
 element can be used for the opposite purpose: to indicate text that has
 been added to the document.
 
-## Overview
-
-## Usage notes
-
 ## Accessibility concerns
 The presence of the `del` element is not announced by most screen
 reading technology in its default configuration. It can be made to be

--- a/content/html/elements/details/prose.md
+++ b/content/html/elements/details/prose.md
@@ -40,8 +40,6 @@ The common use of a triangle which rotates or twists around to
 represent opening or closing the widget is why these are sometimes
 called "twisties".
 
-## Overview
-
 ## Events
 
 In addition to the usual events supported by HTML elements, the

--- a/content/html/elements/details/prose.md
+++ b/content/html/elements/details/prose.md
@@ -1,11 +1,10 @@
-<!-- <short-description> -->
+## Short description
 The **HTML Details Element (`<details>`)** creates a disclosure widget
 in which information is visible only when the widget is toggled into an
 "open" state. A summary or label can be provided using
 the [`<summary>`](/en-US/docs/Web/HTML/Element/summary) element.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
 A disclosure widget is typically presented onscreen using a small
 triangle which rotates (or twists) to indicate open/closed status, with
 a label next to the triangle. If the first child of the `<details>`
@@ -40,14 +39,10 @@ element.
 The common use of a triangle which rotates or twists around to
 represent opening or closing the widget is why these are sometimes
 called "twisties".
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-<!-- </usage-notes> -->
+## Overview
 
-<!-- <events> -->
-Events
-------
+## Events
 
 In addition to the usual events supported by HTML elements, the
 `<details>` element supports the `toggle` event, which is dispatched to
@@ -68,11 +63,7 @@ details.addEventListener("toggle", event => {
   }
 });
 ```
-<!-- </events> -->
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   [`<summary>`](/en-US/docs/Web/HTML/Element/summary)
-<!-- </see-also> -->
+- [`<summary>`](/en-US/docs/Web/HTML/Element/summary)

--- a/content/html/elements/dfn/prose.md
+++ b/content/html/elements/dfn/prose.md
@@ -11,8 +11,6 @@ pairing, or the
 element which is the nearest ancestor of the `<dfn>` is considered to be
 the definition of the term.
 
-## Overview
-
 ## Usage notes
 
 - The `<dfn>` element marks the term being defined; the definition of

--- a/content/html/elements/dfn/prose.md
+++ b/content/html/elements/dfn/prose.md
@@ -1,4 +1,5 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML Definition element** (**\<dfn>**) is used to indicate the
 term being defined within the context of a definition phrase or
 sentence. The
@@ -9,41 +10,37 @@ pairing, or the
 [`<section>`](/en-US/docs/Web/HTML/Element/section)
 element which is the nearest ancestor of the `<dfn>` is considered to be
 the definition of the term.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Usage notes
 
--   The `<dfn>` element marks the term being defined; the definition of
-    the term should be given by the surrounding
-    [`<p>`](/en-US/docs/Web/HTML/Element/p),
-    [`<section>`](/en-US/docs/Web/HTML/Element/section)
-    or definition list group (usually a
-    [`<dt>`](/en-US/docs/Web/HTML/Element/dt),
-    [`<dd>`](/en-US/docs/Web/HTML/Element/dd)
-    pair).
+- The `<dfn>` element marks the term being defined; the definition of
+  the term should be given by the surrounding
+  [`<p>`](/en-US/docs/Web/HTML/Element/p),
+  [`<section>`](/en-US/docs/Web/HTML/Element/section)
+  or definition list group (usually a
+  [`<dt>`](/en-US/docs/Web/HTML/Element/dt),
+  [`<dd>`](/en-US/docs/Web/HTML/Element/dd)
+  pair).
 
 ### Specifying the term being defined
 
 The term being defined is identified following these rules:
 
-1.  If the `<dfn>` element has a `title` attribute, the value of the
-    `title` attribute is considered to be the term being defined. The
-    element must still have text within it, but that text may be an
-    abbreviation (perhaps using
-    [`<abbr>`](/en-US/docs/Web/HTML/Element/abbr))
-    or another form of the term.
-2.  If the `<dfn>` contains a single child element and does not have any
-    text content of its own, and the child element is an
-    [`<abbr>`](/en-US/docs/Web/HTML/Element/abbr)
-    element with a `title` attribute itself, then the exact value of the
-    `<abbr>` element's `title` is the term being defined.
-3.  Otherwise, the text content of the `<dfn>` element is the term being
-    defined.
+1. If the `<dfn>` element has a `title` attribute, the value of the
+   `title` attribute is considered to be the term being defined. The
+   element must still have text within it, but that text may be an
+   abbreviation (perhaps using
+   [`<abbr>`](/en-US/docs/Web/HTML/Element/abbr))
+   or another form of the term.
+2. If the `<dfn>` contains a single child element and does not have any
+   text content of its own, and the child element is an
+   [`<abbr>`](/en-US/docs/Web/HTML/Element/abbr)
+   element with a `title` attribute itself, then the exact value of the
+   `<abbr>` element's `title` is the term being defined.
+3. Otherwise, the text content of the `<dfn>` element is the term being
+   defined.
 
 If the `<dfn>` element has a `title` attribute, it *must* contain the
 term being defined and no other text.
@@ -56,15 +53,11 @@ link to it using
 elements. Such links should be uses of the term, with the intent being
 that the reader can quickly navigate to the term's definition if
 they're not already aware of it, by clicking on the term's link.
-<!-- </usage-notes> -->
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   Elements related to definition lists:
-    [`<dl>`](/en-US/docs/Web/HTML/Element/dl),
-    [`<dt>`](/en-US/docs/Web/HTML/Element/dt),
-    [`<dd>`](/en-US/docs/Web/HTML/Element/dd)
--   [`<abbr>`](/en-US/docs/Web/HTML/Element/abbr)
-<!-- </see-also> -->
+- Elements related to definition lists:
+  [`<dl>`](/en-US/docs/Web/HTML/Element/dl),
+  [`<dt>`](/en-US/docs/Web/HTML/Element/dt),
+  [`<dd>`](/en-US/docs/Web/HTML/Element/dd)
+- [`<abbr>`](/en-US/docs/Web/HTML/Element/abbr)

--- a/content/html/elements/dialog/prose.md
+++ b/content/html/elements/dialog/prose.md
@@ -1,36 +1,29 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<dialog>` element** represents a dialog box or other
 interactive component, such as an inspector or window.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Usage notes
 
--   `<form>` elements can be integrated within a dialog by specifying
-    them with the attribute `method="dialog"`. When such a form is
-    submitted, the dialog is closed with its
-    [`returnValue`](/en-US/docs/Web/API/HTMLDialogElement/returnValue)
-    attribute set to the `value` of the form\'s submit button that was
-    used.
--   The
-    [`::backdrop`](/en-US/docs/Web/CSS/::backdrop)
-    CSS pseudo-element can be used to style behind a `<dialog>` element,
-    for example to dim inaccessible content whilst a modal dialog is
-    active. The backdrop is only drawn when the dialog element is
-    displayed with
-    [`HTMLDialogElement.showModal()`](/en-US/docs/Web/API/HTMLDialogElement/showModal).
-<!-- </usage-notes> -->
+- `<form>` elements can be integrated within a dialog by specifying
+  them with the attribute `method="dialog"`. When such a form is
+  submitted, the dialog is closed with its
+  [`returnValue`](/en-US/docs/Web/API/HTMLDialogElement/returnValue)
+  attribute set to the `value` of the form\'s submit button that was
+  used.
+- The
+  [`::backdrop`](/en-US/docs/Web/CSS/::backdrop)
+  CSS pseudo-element can be used to style behind a `<dialog>` element,
+  for example to dim inaccessible content whilst a modal dialog is
+  active. The backdrop is only drawn when the dialog element is
+  displayed with
+  [`HTMLDialogElement.showModal()`](/en-US/docs/Web/API/HTMLDialogElement/showModal).
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   The `close` event
--   The `cancel` event
--   [HTML forms guide](/en-US/docs/Web/Guide/HTML/Forms).
--   The [`::backdrop`](/en-US/docs/Web/CSS/::backdrop) pseudo-element
-<!-- </see-also> -->
+- The `close` event
+- The `cancel` event
+- [HTML forms guide](/en-US/docs/Web/Guide/HTML/Forms).
+- The [`::backdrop`](/en-US/docs/Web/CSS/::backdrop) pseudo-element

--- a/content/html/elements/dialog/prose.md
+++ b/content/html/elements/dialog/prose.md
@@ -3,8 +3,6 @@
 The **HTML `<dialog>` element** represents a dialog box or other
 interactive component, such as an inspector or window.
 
-## Overview
-
 ## Usage notes
 
 - `<form>` elements can be integrated within a dialog by specifying

--- a/content/html/elements/div/prose.md
+++ b/content/html/elements/div/prose.md
@@ -1,42 +1,34 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML Content Division element** (**`<div>`**) is the generic
 container for flow content. It has no effect on the content or layout
 until styled using CSS.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
 As a "pure" container, the `<div>` element does not inherently
 represent anything. Instead, it's used to group content so it can be
 easily styled using the `class` or `id` attributes, marking a section of
 a document as being written in a different language (using the `lang`
 attribute), and so on.
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Usage notes
 
--   The `<div>` element should be used only when no other semantic
-    element (such as
-    [`<article>`](/en-US/docs/Web/HTML/Element/article)
-    or
-    [`<nav>`](/en-US/docs/Web/HTML/Element/nav))
-    is appropriate.
-<!-- </usage-notes> -->
+- The `<div>` element should be used only when no other semantic
+  element (such as
+  [`<article>`](/en-US/docs/Web/HTML/Element/article)
+  or
+  [`<nav>`](/en-US/docs/Web/HTML/Element/nav))
+  is appropriate.
 
-<!-- <events> -->
-<!-- </events> -->
+## Events
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   Semantic sectioning elements:
-    [`<section>`](/en-US/docs/Web/HTML/Element/section),
-    [`<article>`](/en-US/docs/Web/HTML/Element/article),
-    [`<nav>`](/en-US/docs/Web/HTML/Element/nav),
-    [`<header>`](/en-US/docs/Web/HTML/Element/header),
-    [`<footer>`](/en-US/docs/Web/HTML/Element/footer)
--   [`<span>`](/en-US/docs/Web/HTML/Element/span)
-    element for styling of phrasing content
-<!-- </see-also> -->
+- Semantic sectioning elements:
+  [`<section>`](/en-US/docs/Web/HTML/Element/section),
+  [`<article>`](/en-US/docs/Web/HTML/Element/article),
+  [`<nav>`](/en-US/docs/Web/HTML/Element/nav),
+  [`<header>`](/en-US/docs/Web/HTML/Element/header),
+  [`<footer>`](/en-US/docs/Web/HTML/Element/footer)
+- [`<span>`](/en-US/docs/Web/HTML/Element/span)
+  element for styling of phrasing content

--- a/content/html/elements/div/prose.md
+++ b/content/html/elements/div/prose.md
@@ -20,8 +20,6 @@ attribute), and so on.
   [`<nav>`](/en-US/docs/Web/HTML/Element/nav))
   is appropriate.
 
-## Events
-
 ## See also
 
 - Semantic sectioning elements:

--- a/content/html/elements/dl/prose.md
+++ b/content/html/elements/dl/prose.md
@@ -1,4 +1,5 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<dl>`** element represents a description list. The element
 encloses a list of groups of terms (specified using the
 [`<dt>`](/en-US/docs/Web/HTML/Element/dt)
@@ -6,14 +7,11 @@ element) and descriptions (provided by
 [`<dd>`](/en-US/docs/Web/HTML/Element/dd)
 elements). Common uses for this element are to implement a glossary or
 to display metadata (a list of key-value pairs).
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Overview
+
+## Usage notes
 
 Do not use this element (or
 [`<ul>`](/en-US/docs/Web/HTML/Element/ul)
@@ -23,12 +21,8 @@ this is a bad practice and obscures the meaning of description lists.
 To change the indentation of a description term, use the
 [CSS](/en-US/docs/CSS) [`margin`](/en-US/docs/Web/CSS/margin)
 property.
-<!-- </usage-notes> -->
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   [`<dt>`](/en-US/docs/Web/HTML/Element/dt) element
--   [`<dd>`](/en-US/docs/Web/HTML/Element/dd) element
-<!-- </see-also> -->
+- [`<dt>`](/en-US/docs/Web/HTML/Element/dt) element
+- [`<dd>`](/en-US/docs/Web/HTML/Element/dd) element

--- a/content/html/elements/dl/prose.md
+++ b/content/html/elements/dl/prose.md
@@ -8,9 +8,6 @@ element) and descriptions (provided by
 elements). Common uses for this element are to implement a glossary or
 to display metadata (a list of key-value pairs).
 
-
-## Overview
-
 ## Usage notes
 
 Do not use this element (or

--- a/content/html/elements/dt/prose.md
+++ b/content/html/elements/dt/prose.md
@@ -1,11 +1,12 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<dt>` element** specifies a term in a description or
 definition list, and as such must be used inside a
 [`<dl>`](/en-US/docs/Web/HTML/Element/dl)
 element.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
+
 It is usually followed by a
 [`<dd>`](/en-US/docs/Web/HTML/Element/dd)
 element; however, multiple `<dt>` elements in a row indicate several
@@ -17,15 +18,12 @@ The subsequent
 [`<dd>`](/en-US/docs/Web/HTML/Element/dd)
 (**Description Details**) element provides the definition or other
 related text associated with the term specified using `<dt>`.
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-<!-- </usage-notes> -->
 
-<!-- <see-also> -->
-See also
---------
+## Usage notes
 
--   [`<dd>`](/en-US/docs/Web/HTML/Element/dd),
-    [`<dl>`](/en-US/docs/Web/HTML/Element/dl)
-<!-- </see-also> -->
+
+## See also
+
+- [`<dd>`](/en-US/docs/Web/HTML/Element/dd),
+  [`<dl>`](/en-US/docs/Web/HTML/Element/dl)

--- a/content/html/elements/dt/prose.md
+++ b/content/html/elements/dt/prose.md
@@ -19,10 +19,6 @@ The subsequent
 (**Description Details**) element provides the definition or other
 related text associated with the term specified using `<dt>`.
 
-
-## Usage notes
-
-
 ## See also
 
 - [`<dd>`](/en-US/docs/Web/HTML/Element/dd),

--- a/content/html/elements/em/prose.md
+++ b/content/html/elements/em/prose.md
@@ -4,9 +4,6 @@ The **HTML `<em>` element** marks text that has stress emphasis. The
 `<em>` element can be nested, with each level of nesting indicating a
 greater degree of emphasis.
 
-
-## Overview
-
 ## Usage notes
 
 The `<em>` element is for words that have a stressed emphasis compared
@@ -53,7 +50,6 @@ Here, there is no added emphasis or importance on the word "Queen
 Mary". It is merely indicated that the object in question is not a
 queen named Mary, but a ship named *Queen Mary*. Another example for
 `<i>` could be: "The word *the* is an article".
-
 
 ## See also
 

--- a/content/html/elements/em/prose.md
+++ b/content/html/elements/em/prose.md
@@ -1,15 +1,13 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<em>` element** marks text that has stress emphasis. The
 `<em>` element can be nested, with each level of nesting indicating a
 greater degree of emphasis.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Overview
+
+## Usage notes
 
 The `<em>` element is for words that have a stressed emphasis compared
 to surrounding text, which is often limited to a word or words of a
@@ -55,11 +53,8 @@ Here, there is no added emphasis or importance on the word "Queen
 Mary". It is merely indicated that the object in question is not a
 queen named Mary, but a ship named *Queen Mary*. Another example for
 `<i>` could be: "The word *the* is an article".
-<!-- </usage-notes> -->
 
-<!-- <see-also> -->
-See also
---------
 
--   [`<i>`](/en-US/docs/Web/HTML/Element/i)
-<!-- </see-also> -->
+## See also
+
+- [`<i>`](/en-US/docs/Web/HTML/Element/i)

--- a/content/html/elements/embed/prose.md
+++ b/content/html/elements/embed/prose.md
@@ -1,11 +1,12 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<embed>` element** embeds external content at the specified
 point in the document. This content is provided by an external
 application or other source of interactive content such as a browser
 plug-in.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
+
 **Note:** This topic documents only the element that is defined as part
 of HTML5. It does not address earlier, non-standardized implementation
 of the element.
@@ -14,11 +15,9 @@ Keep in mind that most modern browsers have deprecated and removed
 support for browser plug-ins, so relying upon `<embed>` is generally not
 wise if you want your site to be operable on the average user\'s
 browser.
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-Usage notes
------------
+
+## Usage notes
 
 You can use the
 [`object-position`](/en-US/docs/Web/CSS/object-position)
@@ -26,24 +25,19 @@ property to adjust the positioning of the embedded object within the
 element's frame, and the [`object-fit`](/en-US/docs/Web/CSS/object-fit)
 property to control how the object\'s size is adjusted to fit within the
 frame.
-<!-- </usage-notes> -->
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   Other elements that are used for embedding content of various types
-    include
-    [`<audio>`](/en-US/docs/Web/HTML/Element/audio),
-    [`<canvas>`](/en-US/docs/Web/HTML/Element/canvas),
-    [`<iframe>`](/en-US/docs/Web/HTML/Element/iframe),
-    [`<img>`](/en-US/docs/Web/HTML/Element/img),
-    `<math>`,
-    [`<object>`](/en-US/docs/Web/HTML/Element/object),
-    [`<svg>`](/en-US/docs/Web/SVG/Element/svg),
-    and [`<video>`](/en-US/docs/Web/HTML/Element/video).
--   Positioning and sizing the embedded content within its frame:
-    [`object-position`](/en-US/docs/Web/CSS/object-position)
-    and [`object-fit`](/en-US/docs/Web/CSS/object-fit)
-
-<!-- </see-also> -->
+- Other elements that are used for embedding content of various types
+  include
+  [`<audio>`](/en-US/docs/Web/HTML/Element/audio),
+  [`<canvas>`](/en-US/docs/Web/HTML/Element/canvas),
+  [`<iframe>`](/en-US/docs/Web/HTML/Element/iframe),
+  [`<img>`](/en-US/docs/Web/HTML/Element/img),
+  `<math>`,
+  [`<object>`](/en-US/docs/Web/HTML/Element/object),
+  [`<svg>`](/en-US/docs/Web/SVG/Element/svg),
+  and [`<video>`](/en-US/docs/Web/HTML/Element/video).
+- Positioning and sizing the embedded content within its frame:
+  [`object-position`](/en-US/docs/Web/CSS/object-position)
+  and [`object-fit`](/en-US/docs/Web/CSS/object-fit)

--- a/content/html/elements/embed/prose.md
+++ b/content/html/elements/embed/prose.md
@@ -16,7 +16,6 @@ support for browser plug-ins, so relying upon `<embed>` is generally not
 wise if you want your site to be operable on the average user\'s
 browser.
 
-
 ## Usage notes
 
 You can use the

--- a/content/html/elements/fieldset/prose.md
+++ b/content/html/elements/fieldset/prose.md
@@ -1,10 +1,10 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<fieldset>` element** is used to group several controls as
 well as labels ([`<label>`](/en-US/docs/Web/HTML/Element/label))
 within a web form.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
 The `<fieldset>` element provides a grouping
 for a part of an HTML form, with a nested
 [`<legend>`](/en-US/docs/Web/HTML/Element/legend)
@@ -14,11 +14,8 @@ attributes, the most notable of which are `form`, which can contain the
 on the same page, allowing you to make the `<fieldset>` part of that
 `<form>` even if it is not nested inside it, and `disabled`, which
 allows you to disable the `<fieldset>` and all its contents in one go.
-<!-- </overview> -->
 
-<!-- <styling-with-css> -->
-Styling with CSS
-----------------
+## Styling with CSS
 
 There are several special styling considerations for `<fieldset>`.
 
@@ -53,25 +50,22 @@ inside a
 [`<fieldset>`](/en-US/docs/Web/HTML/Element/fieldset).
 [This GitHub issue](https://github.com/w3c/csswg-drafts/issues/321)
 provides bug tracking links.
-<!-- </styling-with-css> -->
 
-<!-- <see-also> -->
-See also
---------
 
--   Other form-related elements:
-    -   [`<form>`](/en-US/docs/Web/HTML/Element/form)
-    -   [`<legend>`](/en-US/docs/Web/HTML/Element/legend)
-    -   [`<label>`](/en-US/docs/Web/HTML/Element/label)
-    -   [`<button>`](/en-US/docs/Web/HTML/Element/button)
-    -   [`<select>`](/en-US/docs/Web/HTML/Element/select)
-    -   [`<datalist>`](/en-US/docs/Web/HTML/Element/datalist)
-    -   [`<optgroup>`](/en-US/docs/Web/HTML/Element/optgroup)
-    -   [`<option>`](/en-US/docs/Web/HTML/Element/option)
-    -   [`<textarea>`](/en-US/docs/Web/HTML/Element/textarea)
-    -   [`<keygen>`](/en-US/docs/Web/HTML/Element/keygen)
-    -   [`<input>`](/en-US/docs/Web/HTML/Element/input)
-    -   [`<output>`](/en-US/docs/Web/HTML/Element/output)
-    -   [`<progress>`](/en-US/docs/Web/HTML/Element/progress)
-    -   [`<meter>`](/en-US/docs/Web/HTML/Element/meter)
-<!-- </see-also> -->
+## See also
+
+- Other form-related elements:
+  - [`<form>`](/en-US/docs/Web/HTML/Element/form)
+  - [`<legend>`](/en-US/docs/Web/HTML/Element/legend)
+  - [`<label>`](/en-US/docs/Web/HTML/Element/label)
+  - [`<button>`](/en-US/docs/Web/HTML/Element/button)
+  - [`<select>`](/en-US/docs/Web/HTML/Element/select)
+  - [`<datalist>`](/en-US/docs/Web/HTML/Element/datalist)
+  - [`<optgroup>`](/en-US/docs/Web/HTML/Element/optgroup)
+  - [`<option>`](/en-US/docs/Web/HTML/Element/option)
+  - [`<textarea>`](/en-US/docs/Web/HTML/Element/textarea)
+  - [`<keygen>`](/en-US/docs/Web/HTML/Element/keygen)
+  - [`<input>`](/en-US/docs/Web/HTML/Element/input)
+  - [`<output>`](/en-US/docs/Web/HTML/Element/output)
+  - [`<progress>`](/en-US/docs/Web/HTML/Element/progress)
+  - [`<meter>`](/en-US/docs/Web/HTML/Element/meter)

--- a/content/html/elements/fieldset/prose.md
+++ b/content/html/elements/fieldset/prose.md
@@ -5,6 +5,7 @@ well as labels ([`<label>`](/en-US/docs/Web/HTML/Element/label))
 within a web form.
 
 ## Overview
+
 The `<fieldset>` element provides a grouping
 for a part of an HTML form, with a nested
 [`<legend>`](/en-US/docs/Web/HTML/Element/legend)
@@ -50,7 +51,6 @@ inside a
 [`<fieldset>`](/en-US/docs/Web/HTML/Element/fieldset).
 [This GitHub issue](https://github.com/w3c/csswg-drafts/issues/321)
 provides bug tracking links.
-
 
 ## See also
 

--- a/content/html/elements/figcaption/prose.md
+++ b/content/html/elements/figcaption/prose.md
@@ -1,13 +1,9 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<figcaption>` element** represents a caption or legend for
 the rest of the contents its parent
 [`<figure>`](/en-US/docs/Web/HTML/Element/figure)
 element, if any.
-<!-- </short-description> -->
 
-<!-- <see-also> -->
-See also
---------
-
--   The [`<figure>`](/en-US/docs/Web/HTML/Element/figure) element.
-<!-- </see-also> -->
+## See also
+- The [`<figure>`](/en-US/docs/Web/HTML/Element/figure) element.

--- a/content/html/elements/figcaption/prose.md
+++ b/content/html/elements/figcaption/prose.md
@@ -6,4 +6,5 @@ the rest of the contents its parent
 element, if any.
 
 ## See also
+
 - The [`<figure>`](/en-US/docs/Web/HTML/Element/figure) element.

--- a/content/html/elements/figure/prose.md
+++ b/content/html/elements/figure/prose.md
@@ -1,32 +1,25 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<figure>` element** represents self-contained content,
 frequently with a caption
 ([`<figcaption>`](/en-US/docs/Web/HTML/Element/figcaption)),
 and is typically referenced as a single unit.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Usage notes
 
--   Usually a `<figure>` is an image, illustration, diagram, code
-    snippet, etc., that is referenced in the main flow of a document,
-    but that can be moved to another part of the document or to an
-    appendix without affecting the main flow.
--   Being a [sectioning root](/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#Sectioning_roots),
-    the outline of the content of the `<figure>` element is excluded
-    from the main outline of the document.
--   A caption can be associated with the `<figure>` element by inserting
-    a [`<figcaption>`](/en-US/docs/Web/HTML/Element/figcaption)
-    inside it (as the first or the last child).
-<!-- </usage-notes> -->
+- Usually a `<figure>` is an image, illustration, diagram, code
+  snippet, etc., that is referenced in the main flow of a document,
+  but that can be moved to another part of the document or to an
+  appendix without affecting the main flow.
+- Being a [sectioning root](/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#Sectioning_roots),
+  the outline of the content of the `<figure>` element is excluded
+  from the main outline of the document.
+- A caption can be associated with the `<figure>` element by inserting
+  a [`<figcaption>`](/en-US/docs/Web/HTML/Element/figcaption)
+  inside it (as the first or the last child).
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   The [`<figcaption>`](/en-US/docs/Web/HTML/Element/figcaption) element.
-<!-- </see-also> -->
+- The [`<figcaption>`](/en-US/docs/Web/HTML/Element/figcaption) element.

--- a/content/html/elements/figure/prose.md
+++ b/content/html/elements/figure/prose.md
@@ -5,8 +5,6 @@ frequently with a caption
 ([`<figcaption>`](/en-US/docs/Web/HTML/Element/figcaption)),
 and is typically referenced as a single unit.
 
-## Overview
-
 ## Usage notes
 
 - Usually a `<figure>` is an image, illustration, diagram, code

--- a/content/html/elements/footer/prose.md
+++ b/content/html/elements/footer/prose.md
@@ -1,11 +1,10 @@
 ## Short description
+
 The **HTML `<footer>` element** represents a footer for its nearest
 [sectioning content](/en-US/docs/Web/Guide/HTML/Sections_and_Outlines_of_an_HTML5_document#Defining_sections)
 or [sectioning root](/en-US/docs/Web/Guide/HTML/Sections_and_Outlines_of_an_HTML5_document#Sectioning_roots)
 element. A footer typically contains information about the author of the
 section, copyright data or links to related documents.
-
-## Overview
 
 ## Usage notes
 

--- a/content/html/elements/footer/prose.md
+++ b/content/html/elements/footer/prose.md
@@ -1,57 +1,49 @@
-<!-- <short-description> -->
+## Short description
 The **HTML `<footer>` element** represents a footer for its nearest
 [sectioning content](/en-US/docs/Web/Guide/HTML/Sections_and_Outlines_of_an_HTML5_document#Defining_sections)
 or [sectioning root](/en-US/docs/Web/Guide/HTML/Sections_and_Outlines_of_an_HTML5_document#Sectioning_roots)
 element. A footer typically contains information about the author of the
 section, copyright data or links to related documents.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Usage notes
 
--   Enclose information about the author in an
-    [`<address>`](/en-US/docs/Web/HTML/Element/address)
-    element that can be included into the `<footer>` element.
--   The `<footer>` element is not sectioning content and therefore
-    doesn't introduce a new section in the
-    [outline](/en-US/docs/Sections_and_Outlines_of_an_HTML5_document).
-<!-- </usage-notes> -->
+- Enclose information about the author in an
+  [`<address>`](/en-US/docs/Web/HTML/Element/address)
+  element that can be included into the `<footer>` element.
+- The `<footer>` element is not sectioning content and therefore
+  doesn't introduce a new section in the
+  [outline](/en-US/docs/Sections_and_Outlines_of_an_HTML5_document).
 
-<!-- <accessibility-concerns> -->
+## Accessibility concerns
+
 The [VoiceOver](https://help.apple.com/voiceover/info/guide/) screen
 reader has an issue where the footer [landmark
 role](/en-US/docs/Learn/Accessibility/WAI-ARIA_basics#SignpostsLandmarks)
 is not announced in the landmark rotor. To address this, add
 `role="contentinfo"` to the `footer` element.
 
--   [WebKit Bugzilla: 146930 -- AX: HTML native elements (header,
-    footer, main, aside, nav) should work the same as ARIA landmarks,
-    sometimes they don't](https://bugs.webkit.org/show_bug.cgi?id=146930)
-<!-- </accessibility-concerns> -->
+- [WebKit Bugzilla: 146930 -- AX: HTML native elements (header,
+  footer, main, aside, nav) should work the same as ARIA landmarks,
+  sometimes they don't](https://bugs.webkit.org/show_bug.cgi?id=146930)
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   Other section-related elements:
-    [`<body>`](/en-US/docs/Web/HTML/Element/body),
-    [`<nav>`](/en-US/docs/Web/HTML/Element/nav),
-    [`<article>`](/en-US/docs/Web/HTML/Element/article),
-    [`<aside>`](/en-US/docs/Web/HTML/Element/aside),
-    [`<h1>`](/en-US/docs/Web/HTML/Element/h1),
-    [`<h2>`](/en-US/docs/Web/HTML/Element/h2),
-    [`<h3>`](/en-US/docs/Web/HTML/Element/h3),
-    [`<h4>`](/en-US/docs/Web/HTML/Element/h4),
-    [`<h5>`](/en-US/docs/Web/HTML/Element/h5),
-    [`<h6>`](/en-US/docs/Web/HTML/Element/h6),
-    [`<hgroup>`](/en-US/docs/Web/HTML/Element/hgroup),
-    [`<header>`](/en-US/docs/Web/HTML/Element/header),
-    [`<section>`](/en-US/docs/Web/HTML/Element/section),
-    [`<address>`](/en-US/docs/Web/HTML/Element/address);
--   [Sections and outlines of an HTML5 document](/en-US/docs/Web/Guide/HTML/Sections_and_Outlines_of_an_HTML5_document).
--   [ARIA: `contentinfo` role](/en-US/docs/Web/Accessibility/ARIA/Roles/Contentinfo_role)
-<!-- </see-also> -->
+- Other section-related elements:
+  [`<body>`](/en-US/docs/Web/HTML/Element/body),
+  [`<nav>`](/en-US/docs/Web/HTML/Element/nav),
+  [`<article>`](/en-US/docs/Web/HTML/Element/article),
+  [`<aside>`](/en-US/docs/Web/HTML/Element/aside),
+  [`<h1>`](/en-US/docs/Web/HTML/Element/h1),
+  [`<h2>`](/en-US/docs/Web/HTML/Element/h2),
+  [`<h3>`](/en-US/docs/Web/HTML/Element/h3),
+  [`<h4>`](/en-US/docs/Web/HTML/Element/h4),
+  [`<h5>`](/en-US/docs/Web/HTML/Element/h5),
+  [`<h6>`](/en-US/docs/Web/HTML/Element/h6),
+  [`<hgroup>`](/en-US/docs/Web/HTML/Element/hgroup),
+  [`<header>`](/en-US/docs/Web/HTML/Element/header),
+  [`<section>`](/en-US/docs/Web/HTML/Element/section),
+  [`<address>`](/en-US/docs/Web/HTML/Element/address);
+- [Sections and outlines of an HTML5 document](/en-US/docs/Web/Guide/HTML/Sections_and_Outlines_of_an_HTML5_document).
+- [ARIA: `contentinfo` role](/en-US/docs/Web/Accessibility/ARIA/Roles/Contentinfo_role)

--- a/content/html/elements/form/prose.md
+++ b/content/html/elements/form/prose.md
@@ -1,39 +1,35 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<form>` element** represents a document section that
 contains interactive controls for submitting information to a web
 server.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
+
 It is possible to use the
 [`:valid`](/en-US/docs/Web/CSS/:valid) and [`:invalid`](/en-US/docs/Web/CSS/:invalid)
 CSS pseudo-classes to style a `<form>` element based on whether or not
 the individual [`elements`](/en-US/docs/Web/API/HTMLFormElement/elements)
 within the form are valid.
-<!-- </overview> -->
 
-<!-- <see-also> -->
+## See also
 
-See also
---------
-
--   [HTML forms guide](/en-US/docs/Web/Guide/HTML/Forms)
--   Other elements that are used when creating forms:
-    [`<button>`](/en-US/docs/Web/HTML/Element/button),
-    [`<datalist>`](/en-US/docs/Web/HTML/Element/datalist),
-    [`<fieldset>`](/en-US/docs/Web/HTML/Element/fieldset),
-    [`<input>`](/en-US/docs/Web/HTML/Element/input),[`<keygen>`](/en-US/docs/Web/HTML/Element/keygen),
-    [`<label>`](/en-US/docs/Web/HTML/Element/label),
-    [`<legend>`](/en-US/docs/Web/HTML/Element/legend),
-    [`<meter>`](/en-US/docs/Web/HTML/Element/meter),
-    [`<optgroup>`](/en-US/docs/Web/HTML/Element/optgroup),
-    [`<option>`](/en-US/docs/Web/HTML/Element/option),
-    [`<output>`](/en-US/docs/Web/HTML/Element/output),
-    [`<progress>`](/en-US/docs/Web/HTML/Element/progress),
-    [`<select>`](/en-US/docs/Web/HTML/Element/select),
-    [`<textarea>`](/en-US/docs/Web/HTML/Element/textarea).
--   Getting a list of the elements in the form:
-    [`HTMLFormElement.elements`](/en-US/docs/Web/API/HTMLFormElement/elements)
--   [ARIA: Form role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Form_Role)
--   [ARIA: Search role](/en-US/docs/Web/Accessibility/ARIA/Roles/Search_role)
-<!-- </see-also> -->
+- [HTML forms guide](/en-US/docs/Web/Guide/HTML/Forms)
+- Other elements that are used when creating forms:
+  [`<button>`](/en-US/docs/Web/HTML/Element/button),
+  [`<datalist>`](/en-US/docs/Web/HTML/Element/datalist),
+  [`<fieldset>`](/en-US/docs/Web/HTML/Element/fieldset),
+  [`<input>`](/en-US/docs/Web/HTML/Element/input),[`<keygen>`](/en-US/docs/Web/HTML/Element/keygen),
+  [`<label>`](/en-US/docs/Web/HTML/Element/label),
+  [`<legend>`](/en-US/docs/Web/HTML/Element/legend),
+  [`<meter>`](/en-US/docs/Web/HTML/Element/meter),
+  [`<optgroup>`](/en-US/docs/Web/HTML/Element/optgroup),
+  [`<option>`](/en-US/docs/Web/HTML/Element/option),
+  [`<output>`](/en-US/docs/Web/HTML/Element/output),
+  [`<progress>`](/en-US/docs/Web/HTML/Element/progress),
+  [`<select>`](/en-US/docs/Web/HTML/Element/select),
+  [`<textarea>`](/en-US/docs/Web/HTML/Element/textarea).
+- Getting a list of the elements in the form:
+  [`HTMLFormElement.elements`](/en-US/docs/Web/API/HTMLFormElement/elements)
+- [ARIA: Form role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Form_Role)
+- [ARIA: Search role](/en-US/docs/Web/Accessibility/ARIA/Roles/Search_role)

--- a/content/html/elements/h1-h6/prose.md
+++ b/content/html/elements/h1-h6/prose.md
@@ -4,8 +4,6 @@ The **HTML `<h1>`--`<h6>` elements** represent six levels of section
 headings. `<h1>` is the highest section level and `<h6>` is the
 lowest.
 
-## Overview
-
 ## Usage notes
 
 - Heading information may be used by user agents, for example, to

--- a/content/html/elements/h1-h6/prose.md
+++ b/content/html/elements/h1-h6/prose.md
@@ -1,30 +1,26 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<h1>`--`<h6>` elements** represent six levels of section
 headings. `<h1>` is the highest section level and `<h6>` is the
 lowest.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Usage notes
 
--   Heading information may be used by user agents, for example, to
-    construct a table of contents for a document automatically.
--   Do not use lower levels to decrease heading font size: use the
-    [CSS](/en-US/docs/Web/CSS) [`font-size`](/en-US/docs/Web/CSS/font-size)
-    property instead.
--   Avoid skipping heading levels: always start from `<h1>`, next use
-    `<h2>` and so on.
--   You should consider avoiding using `<h1>` more than once on a page.
-    See [Defining sections](/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#Defining_sections)
-    in [Using HTML sections and outlines](/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines)
-    for more information.
-<!-- </usage-notes> -->
+- Heading information may be used by user agents, for example, to
+  construct a table of contents for a document automatically.
+- Do not use lower levels to decrease heading font size: use the
+  [CSS](/en-US/docs/Web/CSS) [`font-size`](/en-US/docs/Web/CSS/font-size)
+  property instead.
+- Avoid skipping heading levels: always start from `<h1>`, next use
+  `<h2>` and so on.
+- You should consider avoiding using `<h1>` more than once on a page.
+  See [Defining sections](/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#Defining_sections)
+  in [Using HTML sections and outlines](/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines)
+  for more information.
 
-<!-- <accessibility-concerns> -->
+## Accessibility concerns
 ### Navigation
 
 A common navigation technique for users of screen reading software is
@@ -56,34 +52,34 @@ content of the page. Most screen readers can also generate an ordered
 list of all the headings on a page, which can help a person quickly
 determine the hierarchy of the content:
 
-1.  `h1` Beetles
-    1.  `h2` Etymology
-    2.  `h2` Distribution and Diversity
-    3.  `h2` Evolution
-        1.  `h3` Late Paleozoic
-        2.  `h3` Jurassic
-        3.  `h3` Cretaceous
-        4.  `h3` Cenozoic
-    4.  `h2` External Morphology
-        1.  `h3` Head
-            1.  `h4` Mouthparts
-        2.  `h3` Thorax
-            1.  `h4` Prothorax
-            2.  `h4` Pterothorax
-        3.  `h3` Legs
-        4.  `h3` Wings
-        5.  `h3` Abdomen
+1. `h1` Beetles
+   1. `h2` Etymology
+   2. `h2` Distribution and Diversity
+   3. `h2` Evolution
+      1. `h3` Late Paleozoic
+      2. `h3` Jurassic
+      3. `h3` Cretaceous
+      4. `h3` Cenozoic
+   4. `h2` External Morphology
+      1. `h3` Head
+         1. `h4` Mouthparts
+      2. `h3` Thorax
+         1. `h4` Prothorax
+         2. `h4` Pterothorax
+      3. `h3` Legs
+      4. `h3` Wings
+      5. `h3` Abdomen
 
 When headings are nested, heading levels may be "skipped" when closing
 a subsection.
 
--   [Headings • Page Structure • WAI Web Accessibility Tutorials](https://www.w3.org/WAI/tutorials/page-structure/headings/)
--   [MDN Understanding WCAG, Guideline 1.3 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#Guideline_1.3_—_Create_content_that_can_be_presented_in_different_ways)
--   [Understanding Success Criterion 1.3.1 \| W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html)
--   [MDN Understanding WCAG, Guideline 2.4 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Operable#Guideline_2.4_—_Navigable_Provide_ways_to_help_users_navigate_find_content_and_determine_where_they_are)
--   [Understanding Success Criterion 2.4.1 \| W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-skip.html)
--   [Understanding Success Criterion 2.4.6 \| W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-descriptive.html)
--   [Understanding Success Criterion 2.4.10 \| W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-headings.html)
+- [Headings • Page Structure • WAI Web Accessibility Tutorials](https://www.w3.org/WAI/tutorials/page-structure/headings/)
+- [MDN Understanding WCAG, Guideline 1.3 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#Guideline_1.3_—_Create_content_that_can_be_presented_in_different_ways)
+- [Understanding Success Criterion 1.3.1 \| W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html)
+- [MDN Understanding WCAG, Guideline 2.4 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Operable#Guideline_2.4_—_Navigable_Provide_ways_to_help_users_navigate_find_content_and_determine_where_they_are)
+- [Understanding Success Criterion 2.4.1 \| W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-skip.html)
+- [Understanding Success Criterion 2.4.6 \| W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-descriptive.html)
+- [Understanding Success Criterion 2.4.10 \| W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-headings.html)
 
 ### Labeling section content
 
@@ -126,15 +122,11 @@ navigation". If labels were not provided, the person using screen
 reading software may have to investigate each `nav` element's contents
 to determine their purpose.
 
--   [Using the `aria-labelledby` attribute](/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute)
--   [Labeling Regions • Page Structure • W3C WAI Web Accessibility Tutorials](https://www.w3.org/WAI/tutorials/page-structure/labels/#using-aria-labelledby)
-<!-- </accessibility-concerns> -->
+- [Using the `aria-labelledby` attribute](/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute)
+- [Labeling Regions • Page Structure • W3C WAI Web Accessibility Tutorials](https://www.w3.org/WAI/tutorials/page-structure/labels/#using-aria-labelledby)
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   [`<p>`](/en-US/docs/Web/HTML/Element/p)
--   [`<div>`](/en-US/docs/Web/HTML/Element/div)
--   [`<section>`](/en-US/docs/Web/HTML/Element/section)
-<!-- </see-also> -->
+- [`<p>`](/en-US/docs/Web/HTML/Element/p)
+- [`<div>`](/en-US/docs/Web/HTML/Element/div)
+- [`<section>`](/en-US/docs/Web/HTML/Element/section)

--- a/content/html/elements/head/prose.md
+++ b/content/html/elements/head/prose.md
@@ -1,30 +1,24 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<head>` element** provides general information (metadata)
 about the document, including its title and links to its scripts and
 style sheets.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
+## Usage notes
 Modern, HTML5-compliant browsers automatically construct a `<head>`
 element if the tags are omitted in the markup. [This behavior cannot be
 guaranteed in ancient browsers](https://www.stevesouders.com/blog/2010/05/12/autohead-my-first-browserscope-user-test/)
-<!-- </usage-notes> -->
 
-<!-- <see-also> -->
+## See also
 
-See also
---------
-
--   Elements that can be used inside a `<head>` element:
-    [`<title>`](/en-US/docs/Web/HTML/Element/title),
-    [`<base>`](/en-US/docs/Web/HTML/Element/base),
-    [`<link>`](/en-US/docs/Web/HTML/Element/link),
-    [`<style>`](/en-US/docs/Web/HTML/Element/style),
-    [`<meta>`](/en-US/docs/Web/HTML/Element/meta),
-    [`<script>`](/en-US/docs/Web/HTML/Element/script),
-    [`<noscript>`](/en-US/docs/Web/HTML/Element/noscript),
-    [`<template>`](/en-US/docs/Web/HTML/Element/template)
-<!-- </see-also> -->
+- Elements that can be used inside a `<head>` element:
+  [`<title>`](/en-US/docs/Web/HTML/Element/title),
+  [`<base>`](/en-US/docs/Web/HTML/Element/base),
+  [`<link>`](/en-US/docs/Web/HTML/Element/link),
+  [`<style>`](/en-US/docs/Web/HTML/Element/style),
+  [`<meta>`](/en-US/docs/Web/HTML/Element/meta),
+  [`<script>`](/en-US/docs/Web/HTML/Element/script),
+  [`<noscript>`](/en-US/docs/Web/HTML/Element/noscript),
+  [`<template>`](/en-US/docs/Web/HTML/Element/template)

--- a/content/html/elements/head/prose.md
+++ b/content/html/elements/head/prose.md
@@ -4,8 +4,6 @@ The **HTML `<head>` element** provides general information (metadata)
 about the document, including its title and links to its scripts and
 style sheets.
 
-## Overview
-
 ## Usage notes
 Modern, HTML5-compliant browsers automatically construct a `<head>`
 element if the tags are omitted in the markup. [This behavior cannot be

--- a/content/html/elements/header/prose.md
+++ b/content/html/elements/header/prose.md
@@ -1,16 +1,14 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<header>` element** represents introductory content,
 typically a group of introductory or navigational aids. It may contain
 some heading elements but also a logo, a search form, an author name,
 and other elements.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Overview
+
+## Usage notes
 
 The `<header>` element is not sectioning content and therefore does not
 introduce a new section in the
@@ -27,26 +25,22 @@ in [the very first website](http://info.cern.ch/), it was originally
 used as the `<head>` element. At some point, it was decided to use a
 different name. This allowed `<header>` to be free to fill a different
 role later on.
-<!-- </usage-notes> -->
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   Others section-related elements:
-    [`<body>`](/en-US/docs/Web/HTML/Element/body),
-    [`<nav>`](/en-US/docs/Web/HTML/Element/nav),
-    [`<article>`](/en-US/docs/Web/HTML/Element/article),
-    [`<aside>`](/en-US/docs/Web/HTML/Element/aside),
-    [`<h1>`](/en-US/docs/Web/HTML/Element/h1),
-    [`<h2>`](/en-US/docs/Web/HTML/Element/h2),
-    [`<h3>`](/en-US/docs/Web/HTML/Element/h3),
-    [`<h4>`](/en-US/docs/Web/HTML/Element/h4),
-    [`<h5>`](/en-US/docs/Web/HTML/Element/h5),
-    [`<h6>`](/en-US/docs/Web/HTML/Element/h6),
-    [`<hgroup>`](/en-US/docs/Web/HTML/Element/hgroup),
-    [`<footer>`](/en-US/docs/Web/HTML/Element/footer),
-    [`<section>`](/en-US/docs/Web/HTML/Element/section),
-    [`<address>`](/en-US/docs/Web/HTML/Element/address).
--   [Sections and outlines of a HTML5 document](/en-US/docs/Web/Guide/HTML/Sections_and_Outlines_of_an_HTML5_document)
-<!-- </see-also> -->
+- Others section-related elements:
+  [`<body>`](/en-US/docs/Web/HTML/Element/body),
+  [`<nav>`](/en-US/docs/Web/HTML/Element/nav),
+  [`<article>`](/en-US/docs/Web/HTML/Element/article),
+  [`<aside>`](/en-US/docs/Web/HTML/Element/aside),
+  [`<h1>`](/en-US/docs/Web/HTML/Element/h1),
+  [`<h2>`](/en-US/docs/Web/HTML/Element/h2),
+  [`<h3>`](/en-US/docs/Web/HTML/Element/h3),
+  [`<h4>`](/en-US/docs/Web/HTML/Element/h4),
+  [`<h5>`](/en-US/docs/Web/HTML/Element/h5),
+  [`<h6>`](/en-US/docs/Web/HTML/Element/h6),
+  [`<hgroup>`](/en-US/docs/Web/HTML/Element/hgroup),
+  [`<footer>`](/en-US/docs/Web/HTML/Element/footer),
+  [`<section>`](/en-US/docs/Web/HTML/Element/section),
+  [`<address>`](/en-US/docs/Web/HTML/Element/address).
+- [Sections and outlines of a HTML5 document](/en-US/docs/Web/Guide/HTML/Sections_and_Outlines_of_an_HTML5_document)

--- a/content/html/elements/header/prose.md
+++ b/content/html/elements/header/prose.md
@@ -5,9 +5,6 @@ typically a group of introductory or navigational aids. It may contain
 some heading elements but also a logo, a search form, an author name,
 and other elements.
 
-
-## Overview
-
 ## Usage notes
 
 The `<header>` element is not sectioning content and therefore does not

--- a/content/html/elements/hr/prose.md
+++ b/content/html/elements/hr/prose.md
@@ -1,20 +1,17 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<hr>` element** represents a thematic break between
 paragraph-level elements: for example, a change of scene in a story, or
 a shift of topic within a section.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
+
 Historically, this has been presented as a horizontal rule or line.
 While it may still be displayed as a horizontal rule in visual browsers,
 this element is now defined in semantic terms, rather than
 presentational terms, so if you wish to draw a horizontal line, you
 should do so using appropriate CSS.
-<!-- </overview> -->
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   [`<p>`](/en-US/docs/Web/HTML/Element/p)
-<!-- </see-also> -->
+- [`<p>`](/en-US/docs/Web/HTML/Element/p)

--- a/content/html/elements/html/prose.md
+++ b/content/html/elements/html/prose.md
@@ -4,11 +4,6 @@ The **HTML `<html>` element** represents the root (top-level element) of
 an HTML document, so it is also referred to as the *root element*. All
 other elements must be descendants of this element.
 
-
-## Overview
-
-## Usage notes
-
 ## Accessibility concerns
 
 Providing a `lang` attribute with a [valid IETF identifying language
@@ -28,7 +23,6 @@ are also announced properly.
 
 - [MDN Understanding WCAG, Guideline 3.1 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Understandable#Guideline_3.1_%E2%80%94_Readable_Make_text_content_readable_and_understandable)
 - [Understanding Success Criterion 3.1.1 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/meaning-doc-lang-id.html)
-
 
 ## See also
 

--- a/content/html/elements/html/prose.md
+++ b/content/html/elements/html/prose.md
@@ -1,16 +1,16 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<html>` element** represents the root (top-level element) of
 an HTML document, so it is also referred to as the *root element*. All
 other elements must be descendants of this element.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-<!-- </usage-notes> -->
+## Overview
 
-<!-- <accessibility-concerns> -->
+## Usage notes
+
+## Accessibility concerns
+
 Providing a `lang` attribute with a [valid IETF identifying language
 tag](https://www.ietf.org/rfc/bcp/bcp47.txt) on the `html` element will
 help screen reading technology determine the proper language to
@@ -26,14 +26,11 @@ such as the page's
 [`<title>`](/en-US/docs/Web/HTML/Element/title),
 are also announced properly.
 
--   [MDN Understanding WCAG, Guideline 3.1 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Understandable#Guideline_3.1_%E2%80%94_Readable_Make_text_content_readable_and_understandable)
--   [Understanding Success Criterion 3.1.1 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/meaning-doc-lang-id.html)
-<!-- </accessibility-concerns> -->
+- [MDN Understanding WCAG, Guideline 3.1 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Understandable#Guideline_3.1_%E2%80%94_Readable_Make_text_content_readable_and_understandable)
+- [Understanding Success Criterion 3.1.1 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/meaning-doc-lang-id.html)
 
-<!-- <see-also> -->
-See also
---------
 
--   MathML top-level element: `<math>`
--   SVG top-level element: [`<svg>`](/en-US/docs/Web/SVG/Element/svg)
-<!-- </see-also> -->
+## See also
+
+- MathML top-level element: `<math>`
+- SVG top-level element: [`<svg>`](/en-US/docs/Web/SVG/Element/svg)

--- a/content/html/elements/i/prose.md
+++ b/content/html/elements/i/prose.md
@@ -1,49 +1,41 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<i>` element** represents a range of text that is set off
 from the normal text for some reason. Some examples include technical
 terms, foreign language phrases, or fictional character thoughts. It is
 typically displayed in italic type.
-<!-- </short-description> -->
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Usage notes
 
--   Use the `<i>` element for text that is set off from the normal prose
-    for readability reasons. This would be a range of text with
-    different semantic meaning than the surrounding text.
--   In earlier versions of the HTML specification, the `<i>` element was
-    merely a presentational element used to display text in italics,
-    much like the `<b>` element was used to display text in bold
-    letters. This is no longer true, as these tags now define semantics
-    rather than typographic appearance. A browser will typically still
-    display the contents of the `<i>` element in italic type, but is, by
-    definition, no longer required to.
--   Typically this element is displayed in italic type. However, it
-    should not be used simply to apply italic styling; use the CSS
-    [`font-style`](/en-US/docs/Web/CSS/font-style)
-    property for that purpose.
--   Be sure the text in question is not actually more appropriate for
-    another element.
-    -   Use [`<em>`](/en-US/docs/Web/HTML/Element/em) to indicate stress emphasis.
-    -   Use [`<strong>`](/en-US/docs/Web/HTML/Element/strong)
-        to indicate stronger importance.
-    -   Use [`<mark>`](/en-US/docs/Web/HTML/Element/mark")
-        to indicate relevance.
-    -   Use
-        [`<cite>`](/en-US/docs/Web/HTML/Element/cite)
-        to mark the name of a work, such as a book, play, or song.
-    -   Use
-        [`<dfn>`](/en-US/docs/Web/HTML/Element/dfn)
-        to mark the defining instance of a term.
--   It is a good idea to use the **class** attribute to identify why the
-    element is being used, so that if the presentation needs to change
-    at a later date, it can be done selectively with style sheets.
-<!-- </usage-notes> -->
+- Use the `<i>` element for text that is set off from the normal prose
+  for readability reasons. This would be a range of text with
+  different semantic meaning than the surrounding text.
+- In earlier versions of the HTML specification, the `<i>` element was
+  merely a presentational element used to display text in italics,
+  much like the `<b>` element was used to display text in bold
+  letters. This is no longer true, as these tags now define semantics
+  rather than typographic appearance. A browser will typically still
+  display the contents of the `<i>` element in italic type, but is, by
+  definition, no longer required to.
+- Typically this element is displayed in italic type. However, it
+  should not be used simply to apply italic styling; use the CSS
+  [`font-style`](/en-US/docs/Web/CSS/font-style)
+  property for that purpose.
+- Be sure the text in question is not actually more appropriate for
+  another element.
+  - Use [`<em>`](/en-US/docs/Web/HTML/Element/em) to indicate stress emphasis.
+  - Use [`<strong>`](/en-US/docs/Web/HTML/Element/strong)
+    to indicate stronger importance.
+  - Use [`<mark>`](/en-US/docs/Web/HTML/Element/mark")
+    to indicate relevance.
+  - Use [`<cite>`](/en-US/docs/Web/HTML/Element/cite)
+    to mark the name of a work, such as a book, play, or song.
+  - Use [`<dfn>`](/en-US/docs/Web/HTML/Element/dfn)
+    to mark the defining instance of a term.
+- It is a good idea to use the **class** attribute to identify why the
+  element is being used, so that if the presentation needs to change
+  at a later date, it can be done selectively with style sheets.
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   [`<em>`](/en-US/docs/Web/HTML/Element/em)
-<!-- </see-also> -->
+- [`<em>`](/en-US/docs/Web/HTML/Element/em)

--- a/content/html/elements/iframe/prose.md
+++ b/content/html/elements/iframe/prose.md
@@ -1,10 +1,10 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML Inline Frame element (`<iframe>`)** represents a nested
 [browsing context](https://developer.mozilla.org/en-US/docs/Glossary/Browsing_context), embedding
 another HTML page into the current one.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
 Each embedded browsing context has its own session
 history. The browsing context that
 embeds the others is called the *parent browsing context*. The *topmost*
@@ -21,11 +21,9 @@ position, alignment, and scaling of the embedded document within the
 `<iframe>` element's box, can be adjusted with the
 [`object-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position) and [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit)
 properties.
-<!-- </overview> -->
 
-<!-- <scripting> -->
-Scripting
----------
+
+## Scripting
 
 Inline frames are included in
 the [`window.frames`](https://developer.mozilla.org/en-US/docs/Web/API/Window/frames) pseudo-array.
@@ -44,9 +42,9 @@ Scripts cannot access most properties in other window objects if the
 script was loaded from a different origin, including scripts inside a
 frame accessing the frame's parent. Cross-origin communication can be
 achieved using [`Window.postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage).
-<!-- </scripting> -->
 
-<!-- <accessibility-concerns> -->
+
+## Accessibility concerns
 People navigating with assistive technology such as a screen reader can
 use the [`title`
 attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title) on an `iframe`
@@ -61,7 +59,5 @@ Without this title, they have to navigate into the `iframe` to determine
 what its embedded content is. This context shift can be confusing and
 time-consuming, especially for pages with multiple `<iframe>`s and/or if
 embeds contain interactive content like video or audio.
-<!-- </accessibility-concerns> -->
 
-<!-- <see-also> -->
-<!-- </see-also> -->
+## See also

--- a/content/html/elements/iframe/prose.md
+++ b/content/html/elements/iframe/prose.md
@@ -22,7 +22,6 @@ position, alignment, and scaling of the embedded document within the
 [`object-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position) and [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit)
 properties.
 
-
 ## Scripting
 
 Inline frames are included in
@@ -43,7 +42,6 @@ script was loaded from a different origin, including scripts inside a
 frame accessing the frame's parent. Cross-origin communication can be
 achieved using [`Window.postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage).
 
-
 ## Accessibility concerns
 People navigating with assistive technology such as a screen reader can
 use the [`title`
@@ -59,5 +57,3 @@ Without this title, they have to navigate into the `iframe` to determine
 what its embedded content is. This context shift can be confusing and
 time-consuming, especially for pages with multiple `<iframe>`s and/or if
 embeds contain interactive content like video or audio.
-
-## See also

--- a/content/html/elements/ins/prose.md
+++ b/content/html/elements/ins/prose.md
@@ -4,14 +4,14 @@ The **HTML `<ins>` element** represents a range of text that has been
 added to a document.
 
 ## Overview
+
 You can use the
 [`<del>`](/en-US/docs/Web/HTML/Element/del)
 element to similarly represent a range of text that has been deleted
 from the document.
 
-## Usage notes
-
 ## Accessibility concerns
+
 The presence of the `ins` element is not announced by most screen
 reading technology in its default configuration. It can be made to be
 announced by using the CSS [`content`](/en-US/docs/Web/CSS/content)

--- a/content/html/elements/ins/prose.md
+++ b/content/html/elements/ins/prose.md
@@ -1,19 +1,17 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<ins>` element** represents a range of text that has been
 added to a document.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
 You can use the
 [`<del>`](/en-US/docs/Web/HTML/Element/del)
 element to similarly represent a range of text that has been deleted
 from the document.
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-<!-- </usage-notes> -->
+## Usage notes
 
-<!-- <accessibility-concerns> -->
+## Accessibility concerns
 The presence of the `ins` element is not announced by most screen
 reading technology in its default configuration. It can be made to be
 announced by using the CSS [`content`](/en-US/docs/Web/CSS/content)
@@ -21,7 +19,7 @@ property, along with the [`::before`](/en-US/docs/Web/CSS/::before)
 and [`::after`](/en-US/docs/Web/CSS/::after) pseudo-elements.
 
 ```css
-    ins::before, 
+    ins::before,
     ins::after {
       clip-path: inset(100%);
       clip: rect(1px, 1px, 1px, 1px);
@@ -46,15 +44,9 @@ content that creates extra verbosity. Because of this, it is important
 not to abuse this technique and only apply it in situations where not
 knowing content has been inserted would adversely affect understanding.
 
--   [Short note on making your mark (more accessible) \| The Paciello
-    Group](https://developer.paciellogroup.com/blog/2017/12/short-note-on-making-your-mark-more-accessible/)
--   [Tweaking Text Level Styles \| Adrian
-    Roselli](http://adrianroselli.com/2017/12/tweaking-text-level-styles.html)
-<!-- </accessibility-concerns> -->
+- [Short note on making your mark (more accessible) | The Paciello Group](https://developer.paciellogroup.com/blog/2017/12/short-note-on-making-your-mark-more-accessible/)
+- [Tweaking Text Level Styles \| Adrian Roselli](http://adrianroselli.com/2017/12/tweaking-text-level-styles.html)
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
--   [`<del>`](/en-US/docs/Web/HTML/Element/del) element for marking deletion into a document
-<!-- </see-also> -->
+- [`<del>`](/en-US/docs/Web/HTML/Element/del) element for marking deletion into a document

--- a/content/html/elements/kbd/prose.md
+++ b/content/html/elements/kbd/prose.md
@@ -1,10 +1,11 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML Keyboard Input element** (**`<kbd>`**) represents a span of
 inline text denoting textual user input from a keyboard, voice input, or
 any other text entry device.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+
+## Overview
 By convention, the [user agent](/en-US/docs/Glossary/user_agent)
 defaults to rendering the contents of a `<kbd>` element using its
 default monospace font, although this is not mandated by the HTML
@@ -14,35 +15,28 @@ standard.
 [`<samp>`](/en-US/docs/Web/HTML/Element/samp)
 (Sample Output) element to represent various forms of input or input
 based on visual cues.
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Usage notes
 
 Other elements can be used in tandem with `<kbd>` to represent more
 specific scenarios:
 
--   Nesting a `<kbd>` element within another `<kbd>` element represents
-    an actual key or other unit of input as a portion of a larger input.
--   Nesting a `<kbd>` element inside a
-    [`<samp>`](/en-US/docs/Web/HTML/Element/samp)
-    element represents input that has been echoed back to the user by
-    the system.
--   Nesting a `<samp>` element inside a `<kbd>` element, on the other
-    hand, represents input which is based on text presented by the
-    system, such as the names of menus and menu items, or the names of
-    buttons displayed on the screen.
+- Nesting a `<kbd>` element within another `<kbd>` element represents
+  an actual key or other unit of input as a portion of a larger input.
+- Nesting a `<kbd>` element inside a
+  [`<samp>`](/en-US/docs/Web/HTML/Element/samp)
+  element represents input that has been echoed back to the user by
+  the system.
+- Nesting a `<samp>` element inside a `<kbd>` element, on the other
+  hand, represents input which is based on text presented by the
+  system, such as the names of menus and menu items, or the names of
+  buttons displayed on the screen.
 
 You can define a custom style to override the browser's default font
 selection for the `<kbd>` element, although the user's preferences may
 potentially override your CSS.
-<!-- </usage-notes> -->
 
-<!-- <see-also> -->
 
-See also
---------
+## See also
 
--   [`<code>`](/en-US/docs/Web/HTML/Element/code)
-<!-- </see-also> -->
+- [`<code>`](/en-US/docs/Web/HTML/Element/code)

--- a/content/html/elements/kbd/prose.md
+++ b/content/html/elements/kbd/prose.md
@@ -4,8 +4,8 @@ The **HTML Keyboard Input element** (**`<kbd>`**) represents a span of
 inline text denoting textual user input from a keyboard, voice input, or
 any other text entry device.
 
-
 ## Overview
+
 By convention, the [user agent](/en-US/docs/Glossary/user_agent)
 defaults to rendering the contents of a `<kbd>` element using its
 default monospace font, although this is not mandated by the HTML
@@ -35,7 +35,6 @@ specific scenarios:
 You can define a custom style to override the browser's default font
 selection for the `<kbd>` element, although the user's preferences may
 potentially override your CSS.
-
 
 ## See also
 

--- a/content/html/elements/label/prose.md
+++ b/content/html/elements/label/prose.md
@@ -1,8 +1,10 @@
 ## Short description
+
 The **HTML `<label>` element** represents a caption for an item in a
 user interface.
 
 ## Overview
+
 Associating a `<label>` with an input element offers some major
 advantages:
 

--- a/content/html/elements/label/prose.md
+++ b/content/html/elements/label/prose.md
@@ -1,22 +1,21 @@
-<!-- <short-description> -->
+## Short description
 The **HTML `<label>` element** represents a caption for an item in a
 user interface.
-<!-- </short-description> -->
 
-<!-- <overview> -->
+## Overview
 Associating a `<label>` with an input element offers some major
 advantages:
 
--   The label text is not only visually associated with its
-    corresponding text input; it is programmatically associated with it
-    too. This means that, for example, a screenreader will read out the
-    label when the user is focused on the form input, making it easier
-    for an assistive technology user to understand what data should be
-    entered.
--   You can click the associated label to focus/activate the input, as
-    well as the input itself. This increased hit area provides an
-    advantage to anyone trying to activate the input, including those
-    using a touch-screen device.
+- The label text is not only visually associated with its
+  corresponding text input; it is programmatically associated with it
+  too. This means that, for example, a screenreader will read out the
+  label when the user is focused on the form input, making it easier
+  for an assistive technology user to understand what data should be
+  entered.
+- You can click the associated label to focus/activate the input, as
+  well as the input itself. This increased hit area provides an
+  advantage to anyone trying to activate the input, including those
+  using a touch-screen device.
 
 To associate the `<label>` with an `<input>` element, you need to give
 the `<input>` an `id` attribute. The `<label>` then needs a `for`
@@ -31,26 +30,20 @@ association is implicit:
   <input type="checkbox" name="peas">
 </label>
 ```
-<!-- </overview> -->
 
-<!-- <usage-notes> -->
-Usage notes
------------
+## Usage notes
 
--   The form control that the label is labeling is called the *labeled
-    control* of the label element. One input can be associated with
-    multiple labels.
--   Labels are not themselves directly associated with forms. They are
-    only indirectly associated with forms through the controls with
-    which they're associated.
--   When a `<label>` is clicked or tapped and it is associated with a
-    form control, the resulting `click` event is also raised for the
-    associated control.
-<!-- </usage-notes> -->
+- The form control that the label is labeling is called the *labeled
+  control* of the label element. One input can be associated with
+  multiple labels.
+- Labels are not themselves directly associated with forms. They are
+  only indirectly associated with forms through the controls with
+  which they're associated.
+- When a `<label>` is clicked or tapped and it is associated with a
+  form control, the resulting `click` event is also raised for the
+  associated control.
 
-<!-- <styling-with-css> -->
-Styling with CSS
-----------------
+## Styling with CSS
 
 There are no special styling considerations for `<label>` elements ---
 structurally they are simple inline elements, and so can be styled in
@@ -60,9 +53,8 @@ or
 [`<a>`](/en-US/docs/Web/HTML/Element/a)
 element. You can apply styling to them in any way you want, as long as
 you don't cause the text to become difficult to read.
-<!-- </styling-with-css> -->
 
-<!-- <accessibility-concerns> -->
+## Accessibility concerns
 ### Interactive content
 
 Don't place interactive elements such as
@@ -122,7 +114,7 @@ element placed within a
 <label class="large-label" for="your-name">
   Your name
   <input id="your-name" name="your-name" type="text">
-</label> 
+</label>
 ```
 
 ### Buttons
@@ -134,26 +126,22 @@ interfere with how assistive technology parses the button input. The
 same applies for the
 [`<button>`](/en-US/docs/Web/HTML/Element/button)
 element.
-<!-- </accessibility-concerns> -->
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
 Other form-related elements:
 
--   [`<form>`](/en-US/docs/Web/HTML/Element/form)
--   [`<input>`](/en-US/docs/Web/HTML/Element/input)
--   [`<button>`](/en-US/docs/Web/HTML/Element/button)
--   [`<datalist>`](/en-US/docs/Web/HTML/Element/datalist)
--   [`<legend>`](/en-US/docs/Web/HTML/Element/legend)
--   [`<select>`](/en-US/docs/Web/HTML/Element/select)
--   [`<optgroup>`](/en-US/docs/Web/HTML/Element/optgroup)
--   [`<option>`](/en-US/docs/Web/HTML/Element/option)
--   [`<textarea>`](/en-US/docs/Web/HTML/Element/textarea)
--   [`<keygen>`](/en-US/docs/Web/HTML/Element/keygen)
--   [`<fieldset>`](/en-US/docs/Web/HTML/Element/fieldset)
--   [`<output>`](/en-US/docs/Web/HTML/Element/output)
--   [`<progress>`](/en-US/docs/Web/HTML/Element/progress)
--   [`<meter>`](/en-US/docs/Web/HTML/Element/meter)
-<!-- </see-also> -->
+- [`<form>`](/en-US/docs/Web/HTML/Element/form)
+- [`<input>`](/en-US/docs/Web/HTML/Element/input)
+- [`<button>`](/en-US/docs/Web/HTML/Element/button)
+- [`<datalist>`](/en-US/docs/Web/HTML/Element/datalist)
+- [`<legend>`](/en-US/docs/Web/HTML/Element/legend)
+- [`<select>`](/en-US/docs/Web/HTML/Element/select)
+- [`<optgroup>`](/en-US/docs/Web/HTML/Element/optgroup)
+- [`<option>`](/en-US/docs/Web/HTML/Element/option)
+- [`<textarea>`](/en-US/docs/Web/HTML/Element/textarea)
+- [`<keygen>`](/en-US/docs/Web/HTML/Element/keygen)
+- [`<fieldset>`](/en-US/docs/Web/HTML/Element/fieldset)
+- [`<output>`](/en-US/docs/Web/HTML/Element/output)
+- [`<progress>`](/en-US/docs/Web/HTML/Element/progress)
+- [`<meter>`](/en-US/docs/Web/HTML/Element/meter)

--- a/content/html/elements/legend/prose.md
+++ b/content/html/elements/legend/prose.md
@@ -1,26 +1,22 @@
-<!-- <short-description> -->
+## Short description
 The **HTML `<legend>` element** represents a caption for the content of
 its parent [`<fieldset>`](/en-US/docs/Web/HTML/Element/fieldset).
-<!-- </short-description> -->
 
-<!-- <see-also> -->
-See also
---------
+## See also
 
 Other form-related elements:
 
--   [`<form>`](/en-US/docs/Web/HTML/Element/form)
--   [`<input>`](/en-US/docs/Web/HTML/Element/input)
--   [`<button>`](/en-US/docs/Web/HTML/Element/button)
--   [`<datalist>`](/en-US/docs/Web/HTML/Element/datalist)
--   [`<label>`](/en-US/docs/Web/HTML/Element/label)
--   [`<select>`](/en-US/docs/Web/HTML/Element/select)
--   [`<optgroup>`](/en-US/docs/Web/HTML/Element/optgroup)
--   [`<option>`](/en-US/docs/Web/HTML/Element/option)
--   [`<textarea>`](/en-US/docs/Web/HTML/Element/textarea)
--   [`<keygen>`](/en-US/docs/Web/HTML/Element/keygen)
--   [`<fieldset>`](/en-US/docs/Web/HTML/Element/fieldset)
--   [`<output>`](/en-US/docs/Web/HTML/Element/output)
--   [`<progress>`](/en-US/docs/Web/HTML/Element/progress)
--   [`<meter>`](/en-US/docs/Web/HTML/Element/meter)
-<!-- </see-also> -->
+- [`<form>`](/en-US/docs/Web/HTML/Element/form)
+- [`<input>`](/en-US/docs/Web/HTML/Element/input)
+- [`<button>`](/en-US/docs/Web/HTML/Element/button)
+- [`<datalist>`](/en-US/docs/Web/HTML/Element/datalist)
+- [`<label>`](/en-US/docs/Web/HTML/Element/label)
+- [`<select>`](/en-US/docs/Web/HTML/Element/select)
+- [`<optgroup>`](/en-US/docs/Web/HTML/Element/optgroup)
+- [`<option>`](/en-US/docs/Web/HTML/Element/option)
+- [`<textarea>`](/en-US/docs/Web/HTML/Element/textarea)
+- [`<keygen>`](/en-US/docs/Web/HTML/Element/keygen)
+- [`<fieldset>`](/en-US/docs/Web/HTML/Element/fieldset)
+- [`<output>`](/en-US/docs/Web/HTML/Element/output)
+- [`<progress>`](/en-US/docs/Web/HTML/Element/progress)
+- [`<meter>`](/en-US/docs/Web/HTML/Element/meter)

--- a/content/html/elements/legend/prose.md
+++ b/content/html/elements/legend/prose.md
@@ -1,4 +1,5 @@
 ## Short description
+
 The **HTML `<legend>` element** represents a caption for the content of
 its parent [`<fieldset>`](/en-US/docs/Web/HTML/Element/fieldset).
 

--- a/content/html/elements/li/prose.md
+++ b/content/html/elements/li/prose.md
@@ -11,10 +11,6 @@ In menus and unordered lists, list items are usually displayed using
 bullet points. In ordered lists, they are usually displayed with an
 ascending counter on the left, such as a number or letter.
 
-## Overview
-
-## Usage notes
-
 ## Styling with CSS
 
 Use the

--- a/content/html/elements/li/prose.md
+++ b/content/html/elements/li/prose.md
@@ -1,4 +1,5 @@
-<!-- <short-description> -->
+## Short description
+
 The **HTML `<li>` element** is used to represent an item in a list. It
 must be contained in a parent element: an ordered list
 ([`<ol>`](/en-US/docs/Web/HTML/Element/ol)),
@@ -9,41 +10,29 @@ or a menu
 In menus and unordered lists, list items are usually displayed using
 bullet points. In ordered lists, they are usually displayed with an
 ascending counter on the left, such as a number or letter.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
-<!-- </usage-notes> -->
+## Usage notes
 
-<!-- <styling-with-css> -->
-Styling with CSS
-----------------
+## Styling with CSS
 
 Use the
 [`list-style-image`](/en-US/docs/Web/CSS/list-style-image),
 [`list-style-position`](/en-US/docs/Web/CSS/list-style-position), and
 [`list-style-type`](/en-US/docs/Web/CSS/list-style-type)
 properties to style list items.
-<!-- </styling-with-css> -->
 
-<!-- <see-also> -->
+## See also
 
-See also
---------
-
--   Other list-related HTML Elements:
-    [`<ul>`](/en-US/docs/Web/HTML/Element/ul),
-    [`<ol>`](/en-US/docs/Web/HTML/Element/ol),
-    [`<menu>`](/en-US/docs/Web/HTML/Element/menu)
--   CSS properties that may be specially useful to style the `<li>`
-    element:
-    -   the
-        [`list-style`](/en-US/docs/Web/CSS/list-style)
-        property, to choose the way the ordinal is displayed,
-    -   [CSS counters](/en-US/docs/Web/CSS/CSS_Lists_and_Counters/Using_CSS_counters),
-        to handle complex nested lists,
-    -   the [`margin`](/en-US/docs/Web/CSS/margin)
-        property, to control the indent of the list item.
-<!-- </see-also> -->
+- Other list-related HTML Elements:
+  [`<ul>`](/en-US/docs/Web/HTML/Element/ul),
+  [`<ol>`](/en-US/docs/Web/HTML/Element/ol),
+  [`<menu>`](/en-US/docs/Web/HTML/Element/menu)
+- CSS properties that may be specially useful to style the `<li>`
+  element:
+  - the [`list-style`](/en-US/docs/Web/CSS/list-style)
+    property, to choose the way the ordinal is displayed,
+  - [CSS counters](/en-US/docs/Web/CSS/CSS_Lists_and_Counters/Using_CSS_counters),
+    to handle complex nested lists,
+  - the [`margin`](/en-US/docs/Web/CSS/margin) property, to control the indent of the list item.

--- a/content/html/elements/table/prose.md
+++ b/content/html/elements/table/prose.md
@@ -1,16 +1,13 @@
-<!-- <short-description> -->
+## Short description
 The **HTML `<table>` element** represents tabular data --- that is,
 information presented in a two-dimensional table comprised of rows and
 columns of cells containing data.
-<!-- </short-description> -->
 
-<!-- <overview> -->
-<!-- </overview> -->
+## Overview
 
-<!-- <usage-notes> -->
-<!-- </usage-notes> -->
+## Usage notes
 
-<!-- <accessibility-concerns> -->
+## Accessibility concerns
 ### Captions
 
 By supplying a
@@ -101,11 +98,7 @@ the header(s) the cell is associated with.
   header cells in data tables \| Techniques for W3C WCAG
   2.0](https://www.w3.org/TR/WCAG20-TECHS/H43.html)
 
-<!-- </accessibility-concerns> -->
-
-<!-- <see-also> -->
-See also
---------
+## See also
 
 - Other table-related HTML Elements:
   [`<caption>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption),
@@ -118,21 +111,20 @@ See also
   [`<thead>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead),
   [`<tr>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr);
 - CSS properties that may be especially useful to style the `<table>` element:
-    - [`width`](https://developer.mozilla.org/en-US/docs/Web/CSS/width)
-      to control the width of the table;
-    - [`border`](https://developer.mozilla.org/en-US/docs/Web/CSS/border),
-      [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style),
-      [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color),
-      [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width),
-      [`border-collapse`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-collapse),
-      [`border-spacing`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-spacing)
-      to control the aspect of cell borders, rules and frame;
-    - [`margin`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin)
-      and
-      [`padding`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding)
-      to style the individual cell content;
-    - [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align)
-      and
-      [`vertical-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align)
-      to define the alignment of text and cell content.
-<!-- </see-also> -->
+  - [`width`](https://developer.mozilla.org/en-US/docs/Web/CSS/width)
+    to control the width of the table;
+  - [`border`](https://developer.mozilla.org/en-US/docs/Web/CSS/border),
+    [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style),
+    [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color),
+    [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width),
+    [`border-collapse`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-collapse),
+    [`border-spacing`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-spacing)
+    to control the aspect of cell borders, rules and frame;
+  - [`margin`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin)
+    and
+    [`padding`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding)
+    to style the individual cell content;
+  - [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align)
+    and
+    [`vertical-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align)
+    to define the alignment of text and cell content.

--- a/content/html/elements/table/prose.md
+++ b/content/html/elements/table/prose.md
@@ -1,11 +1,8 @@
 ## Short description
+
 The **HTML `<table>` element** represents tabular data --- that is,
 information presented in a two-dimensional table comprised of rows and
 columns of cells containing data.
-
-## Overview
-
-## Usage notes
 
 ## Accessibility concerns
 ### Captions

--- a/content/html/elements/video/prose.md
+++ b/content/html/elements/video/prose.md
@@ -1,7 +1,10 @@
-<!-- short-description -->
+## Short descriptions
+
 The **HTML Video element** (**`<video>`**) embeds a media player which
 supports video playback into the document.
-<!-- overview -->
+
+## Overview
+
 You can use `<video>` for audio content as well, but the [`<audio>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio)
 element may provide a more appropriate user experience.
 
@@ -51,9 +54,8 @@ A good general source of information on using HTML `<video>` is the
 [Video and audio
 content](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content)
 beginner's tutorial.
-<!-- usage-notes -->
-Usage notes
------------
+
+## Usage notes
 
 ### Styling with CSS
 
@@ -99,7 +101,9 @@ AddType video/webm .webm
 
 Your web host may provide an easy interface to MIME type configuration
 changes for new technologies until a global update naturally occurs.
-<!-- accessibility-concerns -->
+
+## Accessibility concerns
+
 Videos should provide both captions and transcripts that accurately
 describe its content (see [Adding captions and subtitles to HTML5
 video](https://developer.mozilla.org/en-US/docs/Web/Apps/Fundamentals/Audio_and_video_delivery/Adding_captions_and_subtitles_to_HTML5_video)
@@ -151,9 +155,7 @@ setting](https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API#Cue_setting
 - [Understanding Success Criterion 1.2.2 | W3C Understanding WCAG
   2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/media-equiv-captions.html)
 
-<!-- see-also -->
-See also
---------
+## See also
 
 - [Media formats supported by the audio and video
   elements](https://developer.mozilla.org/en-US/docs/Media_formats_supported_by_the_audio_and_video_elements)
@@ -166,4 +168,3 @@ See also
   canvas](https://developer.mozilla.org/en-US/docs/Manipulating_video_using_canvas)
 - [Configuring servers for Ogg
   media](https://developer.mozilla.org/en-US/docs/Configuring_servers_for_Ogg_media)
-<!-- </see-also> -->

--- a/content/html/elements/video/prose.md
+++ b/content/html/elements/video/prose.md
@@ -1,4 +1,3 @@
-
 ## Short description
 
 The **HTML Video element** (**`<video>`**) embeds a media player which

--- a/package-lock.json
+++ b/package-lock.json
@@ -927,8 +927,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.3.6"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     }
                 },
                 "balanced-match": {
@@ -941,7 +941,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -998,7 +998,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "2.2.4"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "fs.realpath": {
@@ -1011,14 +1011,14 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     }
                 },
                 "glob": {
@@ -1026,12 +1026,12 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "has-unicode": {
@@ -1044,7 +1044,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "2.1.2"
+                        "safer-buffer": "^2.1.0"
                     }
                 },
                 "ignore-walk": {
@@ -1052,7 +1052,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "minimatch": "3.0.4"
+                        "minimatch": "^3.0.4"
                     }
                 },
                 "inflight": {
@@ -1060,8 +1060,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -1079,7 +1079,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -1092,7 +1092,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "brace-expansion": "1.1.11"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -1105,8 +1105,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.0"
                     }
                 },
                 "minizlib": {
@@ -1114,7 +1114,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "2.2.4"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "mkdirp": {
@@ -1135,9 +1135,9 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "iconv-lite": "0.4.21",
-                        "sax": "1.2.4"
+                        "debug": "^2.1.2",
+                        "iconv-lite": "^0.4.4",
+                        "sax": "^1.2.4"
                     }
                 },
                 "node-pre-gyp": {
@@ -1145,16 +1145,16 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "1.0.3",
-                        "mkdirp": "0.5.1",
-                        "needle": "2.2.0",
-                        "nopt": "4.0.1",
-                        "npm-packlist": "1.1.10",
-                        "npmlog": "4.1.2",
-                        "rc": "1.2.7",
-                        "rimraf": "2.6.2",
-                        "semver": "5.5.0",
-                        "tar": "4.4.1"
+                        "detect-libc": "^1.0.2",
+                        "mkdirp": "^0.5.1",
+                        "needle": "^2.2.0",
+                        "nopt": "^4.0.1",
+                        "npm-packlist": "^1.1.6",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^4"
                     }
                 },
                 "nopt": {
@@ -1162,8 +1162,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1.1.1",
-                        "osenv": "0.1.5"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
                 "npm-bundled": {
@@ -1176,8 +1176,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "ignore-walk": "3.0.1",
-                        "npm-bundled": "1.0.3"
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
                     }
                 },
                 "npmlog": {
@@ -1185,10 +1185,10 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -1206,7 +1206,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "os-homedir": {
@@ -1224,8 +1224,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     }
                 },
                 "path-is-absolute": {
@@ -1243,10 +1243,10 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "0.5.1",
-                        "ini": "1.3.5",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
+                        "deep-extend": "^0.5.1",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -1261,13 +1261,13 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "rimraf": {
@@ -1275,7 +1275,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -1313,9 +1313,9 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "string_decoder": {
@@ -1323,7 +1323,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 },
                 "strip-ansi": {
@@ -1331,7 +1331,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
@@ -1344,13 +1344,13 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "1.0.1",
-                        "fs-minipass": "1.2.5",
-                        "minipass": "2.2.4",
-                        "minizlib": "1.1.0",
-                        "mkdirp": "0.5.1",
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
+                        "chownr": "^1.0.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.2.4",
+                        "minizlib": "^1.1.0",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.2"
                     }
                 },
                 "util-deprecate": {
@@ -1363,7 +1363,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     }
                 },
                 "wrappy": {
@@ -2487,12 +2487,79 @@
                 "unified-args": "^6.0.0"
             }
         },
+        "remark-frontmatter": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.1.tgz",
+            "integrity": "sha512-Zj/fDMYnSVgMCeKp8fXIhtMoZq4G6E1dnwfMoO8fVXrm/+oVSiN8YMREtwN2cctgK9EsnYSeS1ExX2hcX/fE1A==",
+            "requires": {
+                "fault": "^1.0.1",
+                "xtend": "^4.0.1"
+            }
+        },
         "remark-lint": {
             "version": "6.0.4",
             "resolved": "https://registry.npmjs.org/remark-lint/-/remark-lint-6.0.4.tgz",
             "integrity": "sha512-miD6SKhjEkLgdJXgAmNhGsdY1yIGAzwpoGIn/59MR6nZhshdxSm9/pLPiw9fK3loNASA3j7k//kea6x5vHb+jQ==",
             "requires": {
                 "remark-message-control": "^4.0.0"
+            }
+        },
+        "remark-lint-blockquote-indentation": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/remark-lint-blockquote-indentation/-/remark-lint-blockquote-indentation-1.0.2.tgz",
+            "integrity": "sha512-u3ruA+4ZZOpt3YmTCdCOcYiGBMSQ/b/iJvZs/fibF6rwSBmkod48aGGJVoOLMuIuTYYbbXpzigxS+PeJwN0CDQ==",
+            "requires": {
+                "mdast-util-to-string": "^1.0.2",
+                "plur": "^3.0.0",
+                "unified-lint-rule": "^1.0.0",
+                "unist-util-generated": "^1.1.0",
+                "unist-util-position": "^3.0.0",
+                "unist-util-visit": "^1.1.1"
+            }
+        },
+        "remark-lint-checkbox-character-style": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/remark-lint-checkbox-character-style/-/remark-lint-checkbox-character-style-1.0.2.tgz",
+            "integrity": "sha512-8hTvHHGj0Ko5Qx9RjBVj9yPO/pOpSFzWVMvszyhZkuH/uy92bab/bmfUwl0/4f8gqsxqyRS/QC/Sp+KivWvYlw==",
+            "requires": {
+                "unified-lint-rule": "^1.0.0",
+                "unist-util-generated": "^1.1.0",
+                "unist-util-position": "^3.0.0",
+                "unist-util-visit": "^1.1.1",
+                "vfile-location": "^2.0.1"
+            }
+        },
+        "remark-lint-code-block-style": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/remark-lint-code-block-style/-/remark-lint-code-block-style-1.0.2.tgz",
+            "integrity": "sha512-fTSCga/lJ710zBaD808NwqzAatVoLQFizvXWpetygKwoAfXCyMYQ9DUdDE5jdDhwOu2JPnKbxY+4t6m4SrKKWA==",
+            "requires": {
+                "unified-lint-rule": "^1.0.0",
+                "unist-util-generated": "^1.1.0",
+                "unist-util-position": "^3.0.0",
+                "unist-util-visit": "^1.1.1"
+            }
+        },
+        "remark-lint-emphasis-marker": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/remark-lint-emphasis-marker/-/remark-lint-emphasis-marker-1.0.2.tgz",
+            "integrity": "sha512-c+uvvnYesMaqy/X0dU62dbI6/rk+4dxMXdnfLC/NKBA8GU+4kljWqluW797S6nBG94QZjKIv8m49zJl38QfImQ==",
+            "requires": {
+                "unified-lint-rule": "^1.0.0",
+                "unist-util-generated": "^1.1.0",
+                "unist-util-position": "^3.0.0",
+                "unist-util-visit": "^1.1.1"
+            }
+        },
+        "remark-lint-fenced-code-marker": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/remark-lint-fenced-code-marker/-/remark-lint-fenced-code-marker-1.0.2.tgz",
+            "integrity": "sha512-yAP59Q1JoI1jjOFCn0GoNx4uDji99ROLvdwvmz7+9YR9guDArBcR4i9Wem/wN6apauWPk2DbAZFavHvbZaT8HQ==",
+            "requires": {
+                "unified-lint-rule": "^1.0.0",
+                "unist-util-generated": "^1.1.0",
+                "unist-util-position": "^3.0.0",
+                "unist-util-visit": "^1.1.1"
             }
         },
         "remark-lint-final-newline": {
@@ -2514,10 +2581,45 @@
                 "unist-util-visit": "^1.1.1"
             }
         },
+        "remark-lint-heading-style": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/remark-lint-heading-style/-/remark-lint-heading-style-1.0.2.tgz",
+            "integrity": "sha512-d0aIbL8PU5LWfZVI8p49vEV5wWIfD/DdUjc+O8j5E0UWUgcRgPGB66xznkOb8AiniXpcaYggRW8hGZsxoYNt1g==",
+            "requires": {
+                "mdast-util-heading-style": "^1.0.2",
+                "unified-lint-rule": "^1.0.0",
+                "unist-util-generated": "^1.1.0",
+                "unist-util-visit": "^1.1.1"
+            }
+        },
+        "remark-lint-link-title-style": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/remark-lint-link-title-style/-/remark-lint-link-title-style-1.0.3.tgz",
+            "integrity": "sha512-1cJ/gNoIwX36FB0w8TiT+/Cy0evSJRyn0uV0jeB5Ik+fX+tVxHRkuX/DtmFw0fGImQW882r/3eaZHaKabVR1yg==",
+            "requires": {
+                "unified-lint-rule": "^1.0.0",
+                "unist-util-generated": "^1.1.0",
+                "unist-util-position": "^3.0.0",
+                "unist-util-visit": "^1.1.1",
+                "vfile-location": "^2.0.1"
+            }
+        },
         "remark-lint-list-item-bullet-indent": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/remark-lint-list-item-bullet-indent/-/remark-lint-list-item-bullet-indent-1.0.2.tgz",
             "integrity": "sha512-zvyQD6mJLRratZjk4Dw7D4vh73L43NXNCcap/6TxcmU9SKO7dXzoh8Ap9tyaFLic0LnHFc3Gx1pqYiPQ7PnL2g==",
+            "requires": {
+                "plur": "^3.0.0",
+                "unified-lint-rule": "^1.0.0",
+                "unist-util-generated": "^1.1.0",
+                "unist-util-position": "^3.0.0",
+                "unist-util-visit": "^1.1.1"
+            }
+        },
+        "remark-lint-list-item-content-indent": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/remark-lint-list-item-content-indent/-/remark-lint-list-item-content-indent-1.0.2.tgz",
+            "integrity": "sha512-I7VkspA/jeMmIWZ4cGmW/4oWnT6fP8pn5n11MR7azRMKgooj3N2qGF084UqrWHh/dLJcakJUNl3NTXv1XCS1Mw==",
             "requires": {
                 "plur": "^3.0.0",
                 "unified-lint-rule": "^1.0.0",
@@ -2661,6 +2763,39 @@
                 "unist-util-visit": "^1.1.1"
             }
         },
+        "remark-lint-rule-style": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/remark-lint-rule-style/-/remark-lint-rule-style-1.0.2.tgz",
+            "integrity": "sha512-D9mMPKA7rtCe4Yx+ryip6FyfNG9uGOaHxRgJClfte7D66QzxiiWtHYyNCXI4rkv8Ax9PrEdpWCPcIl3D2LrXhw==",
+            "requires": {
+                "unified-lint-rule": "^1.0.0",
+                "unist-util-generated": "^1.1.0",
+                "unist-util-position": "^3.0.0",
+                "unist-util-visit": "^1.1.1"
+            }
+        },
+        "remark-lint-strong-marker": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/remark-lint-strong-marker/-/remark-lint-strong-marker-1.0.2.tgz",
+            "integrity": "sha512-oUSKqYJVLgbXe25NmcTOfQ8wsFasc+qhEoGjPEGPuJMV2aZIGuOEbGVqD5B1ckYGBEwbTuet3btvMohz8HaBDQ==",
+            "requires": {
+                "unified-lint-rule": "^1.0.0",
+                "unist-util-generated": "^1.1.0",
+                "unist-util-position": "^3.0.0",
+                "unist-util-visit": "^1.1.1"
+            }
+        },
+        "remark-lint-table-cell-padding": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/remark-lint-table-cell-padding/-/remark-lint-table-cell-padding-1.0.3.tgz",
+            "integrity": "sha512-beXwMK8KAGIDQWixf7wzte4GhyB9w33DxTGgmP4HWOWMVXHvBnufJvnIozBBOH9nOsi1fP8NYRb/01hrgjNnmw==",
+            "requires": {
+                "unified-lint-rule": "^1.0.0",
+                "unist-util-generated": "^1.1.0",
+                "unist-util-position": "^3.0.0",
+                "unist-util-visit": "^1.4.0"
+            }
+        },
         "remark-message-control": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/remark-message-control/-/remark-message-control-4.1.1.tgz",
@@ -2691,6 +2826,26 @@
                 "unist-util-remove-position": "^1.0.0",
                 "vfile-location": "^2.0.0",
                 "xtend": "^4.0.1"
+            }
+        },
+        "remark-preset-lint-consistent": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/remark-preset-lint-consistent/-/remark-preset-lint-consistent-2.0.2.tgz",
+            "integrity": "sha512-BF1cjGga/ed9YJhB/k45ArJHwnzQoNy0oUJYK2j0qJmZxpDqF1w2nOJuqB5MXOobGVAg6chNKTaLhEeuF2hXSA==",
+            "requires": {
+                "remark-lint": "^6.0.0",
+                "remark-lint-blockquote-indentation": "^1.0.0",
+                "remark-lint-checkbox-character-style": "^1.0.0",
+                "remark-lint-code-block-style": "^1.0.0",
+                "remark-lint-emphasis-marker": "^1.0.0",
+                "remark-lint-fenced-code-marker": "^1.0.0",
+                "remark-lint-heading-style": "^1.0.0",
+                "remark-lint-link-title-style": "^1.0.0",
+                "remark-lint-list-item-content-indent": "^1.0.0",
+                "remark-lint-ordered-list-marker-style": "^1.0.0",
+                "remark-lint-rule-style": "^1.0.0",
+                "remark-lint-strong-marker": "^1.0.0",
+                "remark-lint-table-cell-padding": "^1.0.0"
             }
         },
         "remark-preset-lint-recommended": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "scripts": {
         "pretty": "prettier --check scripts/**/*.js",
         "prettify": "prettier --write scripts/**/*.js",
-        "lint-md": "remark content",
+        "lint-md": "remark -q -f content",
         "build-json": "node scripts/build-json/build-json.js",
         "spell-md": "mdspell -a -n -r -x --en-us 'content/**/!(*contributors).md'",
         "test": "npm run lint-md && npm run spell-md"
@@ -28,14 +28,22 @@
         "marked": "0.6.2",
         "mdn-browser-compat-data": "0.x",
         "remark-cli": "6.0.1",
+        "remark-frontmatter": "^1.3.1",
+        "remark-preset-lint-consistent": "^2.0.2",
         "remark-preset-lint-recommended": "3.0.2"
     },
     "remarkConfig": {
         "plugins": [
+            "remark-frontmatter",
+            "remark-preset-lint-consistent",
             "remark-preset-lint-recommended",
             [
                 "remark-lint-list-item-indent",
                 "space"
+            ],
+            [
+                "remark-lint-heading-style",
+                "atx"
             ]
         ]
     },


### PR DESCRIPTION
Another large PR. I'm very sorry about this :(

I was happy to see we're going from HTML comments to headings to demarcate sections :tada: 

However, looking into headings and markdown, I was super unhappy with how there are two heading styles (settext and atx). And of course, because linting in this repo is limited still, we have already used both of them. I dislike the settext style because it is very implicit and it doesn't support all heading levels but just h1 and h2. So, we will always have to also use atx style heading as well. 
Now we're also using headings as one of our main feature to demarcate content, so I believe it is time to lint this and be strict about it. So this PR does a bunch of things to help us to meet content expectations.

- Change comments to atx style headings
- Enforce atx heading style per linter
- Add remark-frontmatter, so that the linter understands that we're using frontmatters and that it doesn't confuse it with settext style headers which we disallow.
- remark-lint doesn't cause the build to fail on warnings normally, but I think we should be strict and have it fail, as our project fails and wins with well formatted and structured content (this is the `-f` option).
- remark-lint is quite verbose and always lists passed files, I think we don't need this (this is the `-q` option)
- Add in "remark-preset-lint-consistent". This looks like a sensible package that helps us to avoid further inconsistencies. It brings the consistent heading styles (and this is the reason I added it, but it also has other things to help being consistent)

Somewhat unrelated is fixing all the other linting errors as I went through this, sorry about that, but I didn't want to go through the files twice to fix what the linter currently yells at us.

Oh, one question that I had while doing this: What to do whith empty sections? Do we want to have the headline or not?  We did have empty html comment sections, so I've preserved this and added empty sections that start with a heading. Let me know if we should rather remove them.