### PR TITLE
If there are no element-specific attributes, make the attributes prop…

### DIFF
--- a/scripts/build-json/build-page-json.js
+++ b/scripts/build-json/build-page-json.js
@@ -55,7 +55,7 @@ function buildPageJSON(elementPath) {
         const attributesPath = path.join(elementPath, meta.attributes['element-specific']);
         element.attributes = attributes.package(attributesPath);
     } else {
-        element.attributes = null;
+        element.attributes = [];
     }
     element.examples = examples.package(examplesPaths);
     element.prose = prose.package(prosePath);


### PR DESCRIPTION
…erty an empty array, rather than null.

This is the stumptown side of a fix for https://github.com/peterbe/mdn2/issues/13. 

With this we make `attributes` an empty array if there are no attributes.

I've tested this against mdn2, and while `make deployment-build` still doesn't work, it gets further on before encountering a different problem :).