### PR TITLE
Change property name from additional-sections to additional_sections

### DIFF
--- a/scripts/build-json/slice-prose.js
+++ b/scripts/build-json/slice-prose.js
@@ -54,7 +54,7 @@ function getSection(node, sections) {
             title: sectionName,
             content: sectionContent
         };
-      sections['additional-sections'].push(additionalSection);
+      sections['additional_sections'].push(additionalSection);
     }
 }
 
@@ -62,7 +62,7 @@ function package(prosePath) {
     const proseMD = fs.readFileSync(prosePath, 'utf8');
     const dom = JSDOM.fragment(marked(proseMD));
     const sections = {
-        'additional-sections': []
+        'additional_sections': []
     };
     let node = dom.firstChild;
     while (node) {


### PR DESCRIPTION
When I changed section demarcators I also updated the code to use "_" rather than "-" for JSON identifiers, but missed `additional-sections` since that isn't generated from an actual heading.

This should enable us to close https://github.com/mdn/stumptown-experiment/issues/34.